### PR TITLE
feat(desktop): 为系统托盘添加可执行文件图标支持

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -46,8 +46,18 @@ const destroyTray = (): void => {
 };
 
 const createTray = (mainWindow: BrowserWindow): Tray => {
-  const icon = nativeImage.createEmpty();
-  const t = new Tray(icon);
+  const t = new Tray(nativeImage.createEmpty());
+  void app.getFileIcon(process.execPath, { size: "small" })
+    .then((icon) => {
+      if (!icon.isEmpty()) {
+        t.setImage(icon);
+      } else {
+        logger.warn("[Tray] default executable icon is empty");
+      }
+    })
+    .catch((error) => {
+      logger.warn("[Tray] failed to load default executable icon", error);
+    });
   if (process.platform === "darwin") {
     t.setTitle(">_");
   }


### PR DESCRIPTION
- 实现异步加载当前可执行文件的图标作为托盘图标
- 增加图标加载失败或为空时的异常处理和日志记录
- 解决托盘图标初始化时显示为空白的问题，提升 UI 表现力