### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+NextShell 是一个基于 Electron + React + TypeScript 的桌面 SSH/运维客户端，使用 Bun Workspace 管理 monorepo。详细的项目结构、命令列表和原生模块排错指南见 `README.md`。
+
+### Runtime requirements
+
+- **Bun 1.3.4**（见 `.bun-version`）
+- **libsecret-1-dev** 和 **build-essential**（编译 `keytar`、`better-sqlite3`、`ssh2`、`node-pty` 等原生模块）
+- Electron 在无头 Linux 环境下运行时依赖 Xvfb（`DISPLAY=:1`）
+
+### Common dev commands
+
+参见 `README.md` 的「常用命令」表格。核心命令：
+
+| 命令 | 说明 |
+|---|---|
+| `bun run setup` | 安装依赖并重建原生模块（首次或 Electron/Bun 版本变更后执行） |
+| `bun run dev` | 启动 Electron 开发模式（Vite dev server on port 5173） |
+| `bun run typecheck` | TypeScript `--noEmit` 检查 |
+| `bun test` | 运行工作区所有 `*.test.ts` |
+
+### Gotchas for Cloud VM
+
+- Electron 启动时会输出 D-Bus 相关 ERROR 日志（`Failed to connect to the bus`）和 WebGL2 blocklisted 错误，这些在无头 Linux 环境下是正常的，不影响功能。
+- `keytar` 在没有桌面密钥环（gnome-keyring）的环境下可能回退到不安全存储，应用会自动生成 device key 作为替代。
+- `bun run dev` 会先通过 Vite 构建 main/preload，然后自动启动 Electron 窗口。
+- 原生模块（`better-sqlite3`, `keytar`, `ssh2`, `node-pty`）需要针对 Electron 的 Node ABI 重建，`bun run setup` 已包含此步骤。如果只需要重建原生模块，可以单独执行 `bun run rebuild:native`。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `AGENTS.md` with Cursor Cloud specific instructions for future cloud agents.

### What's included

- Project overview and runtime requirements (Bun 1.3.4, libsecret-1-dev, build-essential)
- Common dev commands reference (pointing to README.md)
- Cloud VM gotchas:
  - D-Bus / WebGL2 errors in headless Linux are expected and harmless
  - `keytar` fallback behavior without desktop keyring
  - Native module rebuild notes for Electron ABI compatibility

### Update script

The VM startup update script runs:
```bash
export PATH="$HOME/.bun/bin:$PATH"
bun run setup
```

### Verification

All checks pass in the cloud environment:
- `bun run setup` — dependencies installed, native modules rebuilt
- `bun run typecheck` — TypeScript checks pass (0 errors)
- `bun test` — 6 tests pass across 34 files
- `bun run dev` — Electron app starts successfully (Vite on port 5173)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c990bb6f-043d-43c9-897f-f184058d1a22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c990bb6f-043d-43c9-897f-f184058d1a22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

