### PR TITLE
feat: add AI core contracts and settings

### DIFF
--- a/apps/desktop/src/main/services/preferences.ts
+++ b/apps/desktop/src/main/services/preferences.ts
@@ -251,6 +251,39 @@ export const mergePreferences = (
         patch.audit.retentionDays <= 365
           ? patch.audit.retentionDays
           : current.audit.retentionDays
+    },
+    ai: {
+      enabled: patch.ai?.enabled ?? current.ai.enabled,
+      activeProviderId:
+        patch.ai?.activeProviderId !== undefined
+          ? patch.ai.activeProviderId
+          : current.ai.activeProviderId,
+      providers: patch.ai?.providers ?? current.ai.providers,
+      systemPromptOverride:
+        patch.ai?.systemPromptOverride !== undefined
+          ? patch.ai.systemPromptOverride
+          : current.ai.systemPromptOverride,
+      executionTimeoutSec:
+        patch.ai?.executionTimeoutSec !== undefined &&
+        Number.isInteger(patch.ai.executionTimeoutSec) &&
+        patch.ai.executionTimeoutSec >= 5 &&
+        patch.ai.executionTimeoutSec <= 300
+          ? patch.ai.executionTimeoutSec
+          : current.ai.executionTimeoutSec,
+      providerRequestTimeoutSec:
+        patch.ai?.providerRequestTimeoutSec !== undefined &&
+        Number.isInteger(patch.ai.providerRequestTimeoutSec) &&
+        patch.ai.providerRequestTimeoutSec >= 5 &&
+        patch.ai.providerRequestTimeoutSec <= 120
+          ? patch.ai.providerRequestTimeoutSec
+          : current.ai.providerRequestTimeoutSec,
+      providerMaxRetries:
+        patch.ai?.providerMaxRetries !== undefined &&
+        Number.isInteger(patch.ai.providerMaxRetries) &&
+        patch.ai.providerMaxRetries >= 0 &&
+        patch.ai.providerMaxRetries <= 3
+          ? patch.ai.providerMaxRetries
+          : current.ai.providerMaxRetries
     }
   };
 };

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 import type {
+  AiStreamEvent,
+  AiProgressEvent,
   CloudSyncManagerStatusEvent,
   DebugLogEntry,
   SessionDataEvent,
@@ -314,6 +316,28 @@ const api: NextShellApi = {
     restore: (payload) => ipcRenderer.invoke(IPCChannel.RecycleBinRestore, payload),
     purge: (payload) => ipcRenderer.invoke(IPCChannel.RecycleBinPurge, payload),
     clear: () => ipcRenderer.invoke(IPCChannel.RecycleBinClear, {})
+  },
+  ai: {
+    chat: (payload) => ipcRenderer.invoke(IPCChannel.AiChat, payload),
+    approve: (payload) => ipcRenderer.invoke(IPCChannel.AiApprove, payload),
+    abort: (payload) => ipcRenderer.invoke(IPCChannel.AiAbort, payload),
+    history: (payload) => ipcRenderer.invoke(IPCChannel.AiHistory, payload ?? {}),
+    testProvider: (payload) => ipcRenderer.invoke(IPCChannel.AiProviderTest, payload),
+    setApiKey: (payload) => ipcRenderer.invoke(IPCChannel.AiProviderSetApiKey, payload),
+    onStream: (listener) => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: AiStreamEvent) => {
+        listener(payload);
+      };
+      ipcRenderer.on(IPCChannel.AiStreamEvent, handler);
+      return () => { ipcRenderer.off(IPCChannel.AiStreamEvent, handler); };
+    },
+    onProgress: (listener) => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: AiProgressEvent) => {
+        listener(payload);
+      };
+      ipcRenderer.on(IPCChannel.AiProgressEvent, handler);
+      return () => { ipcRenderer.off(IPCChannel.AiProgressEvent, handler); };
+    }
   },
   platform: process.platform,
   ui: {

--- a/apps/desktop/src/renderer/components/SettingsCenterModal.tsx
+++ b/apps/desktop/src/renderer/components/SettingsCenterModal.tsx
@@ -17,6 +17,7 @@ import {
   NetworkSection,
   BackupSection,
   SecuritySection,
+  AiSection,
   AboutSection,
 } from "./settings-center";
 
@@ -466,6 +467,19 @@ export const SettingsCenterModal = ({ open, onClose }: SettingsCenterModalProps)
           onRunBackup={() => void handleRunBackup()}
           onListArchives={() => void handleListArchives()}
           onRestore={(id) => void handleRestore(id)}
+          save={save}
+          message={message}
+        />;
+
+      case "ai":
+        return <AiSection
+          loading={loading}
+          enabled={preferences.ai.enabled}
+          providers={preferences.ai.providers}
+          activeProviderId={preferences.ai.activeProviderId}
+          executionTimeoutSec={preferences.ai.executionTimeoutSec}
+          providerRequestTimeoutSec={preferences.ai.providerRequestTimeoutSec}
+          providerMaxRetries={preferences.ai.providerMaxRetries}
           save={save}
           message={message}
         />;

--- a/apps/desktop/src/renderer/components/settings-center/ai-section.tsx
+++ b/apps/desktop/src/renderer/components/settings-center/ai-section.tsx
@@ -1,0 +1,388 @@
+import { useState } from "react";
+import {
+  Button,
+  Input,
+  InputNumber,
+  Select,
+  Space,
+  Tag,
+  Typography
+} from "antd";
+import { type AiProviderConfig, type AiProviderType } from "@nextshell/core";
+import { SettingsCard, SettingsRow, SettingsSwitchRow } from "./shared-components";
+import type { SaveFn } from "./types";
+import { formatAiErrorMessage } from "../../utils/ai-error-message";
+
+const PROVIDER_TYPE_OPTIONS: Array<{ label: string; value: AiProviderType }> = [
+  { label: "OpenAI 兼容", value: "openai" },
+  { label: "Anthropic Claude", value: "anthropic" },
+  { label: "Google Gemini", value: "gemini" },
+];
+
+const DEFAULT_BASE_URLS: Record<AiProviderType, string> = {
+  openai: "https://api.openai.com/v1",
+  anthropic: "https://api.anthropic.com",
+  gemini: "https://generativelanguage.googleapis.com",
+};
+
+const DEFAULT_MODELS: Record<AiProviderType, string> = {
+  openai: "gpt-4o",
+  anthropic: "claude-sonnet-4-20250514",
+  gemini: "gemini-2.5-flash",
+};
+
+interface AiSectionProps {
+  loading: boolean;
+  enabled: boolean;
+  providers: AiProviderConfig[];
+  activeProviderId?: string;
+  executionTimeoutSec: number;
+  providerRequestTimeoutSec: number;
+  providerMaxRetries: number;
+  save: SaveFn;
+  message: { success: (msg: string) => void; error: (msg: string) => void; warning: (msg: string) => void };
+}
+
+export const AiSection = ({
+  loading,
+  enabled,
+  providers,
+  activeProviderId,
+  executionTimeoutSec,
+  providerRequestTimeoutSec,
+  providerMaxRetries,
+  save,
+  message,
+}: AiSectionProps) => {
+  const [editingProvider, setEditingProvider] = useState<AiProviderConfig | null>(null);
+  const [apiKeyInput, setApiKeyInput] = useState("");
+  const [testing, setTesting] = useState(false);
+
+  const startAddProvider = (): void => {
+    const defaultType: AiProviderType = "openai";
+    setEditingProvider({
+      id: crypto.randomUUID(),
+      type: defaultType,
+      name: "",
+      baseUrl: DEFAULT_BASE_URLS[defaultType],
+      model: DEFAULT_MODELS[defaultType],
+      enabled: true,
+    });
+    setApiKeyInput("");
+  };
+
+  const startEditProvider = (provider: AiProviderConfig): void => {
+    setEditingProvider({ ...provider });
+    setApiKeyInput("");
+  };
+
+  const handleProviderTypeChange = (type: AiProviderType): void => {
+    if (!editingProvider) return;
+    setEditingProvider({
+      ...editingProvider,
+      type,
+      baseUrl: DEFAULT_BASE_URLS[type],
+      model: DEFAULT_MODELS[type],
+    });
+  };
+
+  const handleSaveProvider = async (): Promise<void> => {
+    if (!editingProvider) return;
+    if (!editingProvider.name.trim()) {
+      message.warning("请输入提供商名称");
+      return;
+    }
+    if (!editingProvider.baseUrl.trim()) {
+      message.warning("请输入 API 地址");
+      return;
+    }
+    if (!editingProvider.model.trim()) {
+      message.warning("请输入模型名称");
+      return;
+    }
+
+    if (apiKeyInput.trim()) {
+      try {
+        await window.nextshell.ai.setApiKey({
+          providerId: editingProvider.id,
+          apiKey: apiKeyInput.trim(),
+        });
+        editingProvider.apiKeyRef = `secret://ai-provider-${editingProvider.id}`;
+      } catch (err) {
+        message.error(`保存 API Key 失败：${err instanceof Error ? err.message : "未知错误"}`);
+        return;
+      }
+    }
+
+    const existingIdx = providers.findIndex((p) => p.id === editingProvider.id);
+    const updated = [...providers];
+    if (existingIdx >= 0) {
+      updated[existingIdx] = editingProvider;
+    } else {
+      updated.push(editingProvider);
+    }
+
+    const isFirstProvider = providers.length === 0;
+    save({
+      ai: {
+        providers: updated,
+        ...(isFirstProvider ? { activeProviderId: editingProvider.id, enabled: true } : {}),
+      },
+    });
+
+    setEditingProvider(null);
+    setApiKeyInput("");
+    message.success("提供商配置已保存");
+  };
+
+  const handleRemoveProvider = (id: string): void => {
+    const updated = providers.filter((p) => p.id !== id);
+    const patch: Record<string, unknown> = { providers: updated };
+    if (activeProviderId === id) {
+      patch.activeProviderId = updated[0]?.id;
+    }
+    save({ ai: patch });
+  };
+
+  const handleTestProvider = async (): Promise<void> => {
+    if (!editingProvider) return;
+    const key = apiKeyInput.trim();
+    if (!key) {
+      message.warning("请先输入 API Key 以进行测试");
+      return;
+    }
+    setTesting(true);
+    try {
+      const result = await window.nextshell.ai.testProvider({
+        type: editingProvider.type,
+        baseUrl: editingProvider.baseUrl,
+        model: editingProvider.model,
+        apiKey: key,
+      });
+      if (result.ok) {
+        message.success("连接测试成功");
+      } else {
+        message.error(`连接测试失败：${formatAiErrorMessage(result.error, "未知错误")}`);
+      }
+    } catch (err) {
+      message.error(`测试失败：${formatAiErrorMessage(err, "未知错误")}`);
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <>
+      <SettingsCard title="AI 助手" description="配置大模型接口，使用 AI 辅助执行运维操作">
+        <SettingsSwitchRow
+          label="启用 AI 助手"
+          checked={enabled}
+          disabled={loading}
+          onChange={(v) => save({ ai: { enabled: v } })}
+        />
+
+        {enabled && (
+          <>
+            <SettingsRow label="命令执行超时（秒）" hint="AI 执行单条命令的最大等待时间">
+              <InputNumber
+                min={5}
+                max={300}
+                value={executionTimeoutSec}
+                disabled={loading}
+                onChange={(v) => {
+                  if (v !== null) save({ ai: { executionTimeoutSec: v } });
+                }}
+                style={{ width: 120 }}
+              />
+            </SettingsRow>
+
+            <SettingsRow label="模型请求超时（秒）" hint="单次调用 OpenAI / Claude / Gemini 的最大等待时间">
+              <InputNumber
+                min={5}
+                max={120}
+                value={providerRequestTimeoutSec}
+                disabled={loading}
+                onChange={(v) => {
+                  if (v !== null) save({ ai: { providerRequestTimeoutSec: v } });
+                }}
+                style={{ width: 120 }}
+              />
+            </SettingsRow>
+
+            <SettingsRow label="模型请求重试次数" hint="遇到 429 或 5xx 等可重试错误时的最大自动重试次数">
+              <InputNumber
+                min={0}
+                max={3}
+                value={providerMaxRetries}
+                disabled={loading}
+                onChange={(v) => {
+                  if (v !== null) save({ ai: { providerMaxRetries: v } });
+                }}
+                style={{ width: 120 }}
+              />
+            </SettingsRow>
+
+          </>
+        )}
+      </SettingsCard>
+
+      {enabled && (
+        <SettingsCard
+          title="模型提供商"
+          description="管理大模型 API 接口配置，支持 OpenAI 兼容（含 DeepSeek / Ollama）、Anthropic、Gemini"
+        >
+          {providers.length > 0 && (
+            <div style={{ marginBottom: 12 }}>
+              <SettingsRow label="当前使用">
+                <Select
+                  value={activeProviderId}
+                  disabled={loading}
+                  style={{ width: 200 }}
+                  onChange={(v) => save({ ai: { activeProviderId: v } })}
+                  options={providers
+                    .filter((p) => p.enabled)
+                    .map((p) => ({
+                      label: p.name,
+                      value: p.id,
+                    }))}
+                />
+              </SettingsRow>
+            </div>
+          )}
+
+          {/* Provider list */}
+          <div className="flex flex-col gap-2">
+            {providers.map((provider) => (
+              <div
+                key={provider.id}
+                className="flex items-center justify-between p-2 rounded"
+                style={{ border: "1px solid var(--border)" }}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <Tag color={provider.enabled ? "blue" : "default"}>
+                    {PROVIDER_TYPE_OPTIONS.find((o) => o.value === provider.type)?.label ?? provider.type}
+                  </Tag>
+                  <Typography.Text ellipsis style={{ maxWidth: 160 }}>
+                    {provider.name}
+                  </Typography.Text>
+                  <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                    {provider.model}
+                  </Typography.Text>
+                  {provider.id === activeProviderId && (
+                    <Tag color="green" style={{ marginLeft: 4 }}>当前</Tag>
+                  )}
+                </div>
+                <Space size={4}>
+                  <Button size="small" onClick={() => startEditProvider(provider)}>
+                    编辑
+                  </Button>
+                  <Button size="small" danger onClick={() => handleRemoveProvider(provider.id)}>
+                    删除
+                  </Button>
+                </Space>
+              </div>
+            ))}
+          </div>
+
+          {!editingProvider && (
+            <Button
+              type="dashed"
+              block
+              style={{ marginTop: 8 }}
+              onClick={startAddProvider}
+            >
+              <i className="ri-add-line" /> 添加提供商
+            </Button>
+          )}
+
+          {/* Edit / Add form */}
+          {editingProvider && (
+            <div
+              style={{
+                marginTop: 12,
+                padding: 12,
+                borderRadius: 6,
+                border: "1px solid var(--border)",
+              }}
+            >
+              <Typography.Text strong style={{ fontSize: 13 }}>
+                {providers.some((p) => p.id === editingProvider.id) ? "编辑提供商" : "添加提供商"}
+              </Typography.Text>
+
+              <SettingsRow label="类型">
+                <Select
+                  value={editingProvider.type}
+                  options={PROVIDER_TYPE_OPTIONS}
+                  style={{ width: 200 }}
+                  onChange={handleProviderTypeChange}
+                />
+              </SettingsRow>
+
+              <SettingsRow label="名称">
+                <Input
+                  value={editingProvider.name}
+                  placeholder="如：DeepSeek / 本地 Ollama"
+                  onChange={(e) =>
+                    setEditingProvider({ ...editingProvider, name: e.target.value })
+                  }
+                />
+              </SettingsRow>
+
+              <SettingsRow label="API 地址">
+                <Input
+                  value={editingProvider.baseUrl}
+                  placeholder={DEFAULT_BASE_URLS[editingProvider.type]}
+                  onChange={(e) =>
+                    setEditingProvider({ ...editingProvider, baseUrl: e.target.value })
+                  }
+                />
+              </SettingsRow>
+
+              <SettingsRow label="模型">
+                <Input
+                  value={editingProvider.model}
+                  placeholder={DEFAULT_MODELS[editingProvider.type]}
+                  onChange={(e) =>
+                    setEditingProvider({ ...editingProvider, model: e.target.value })
+                  }
+                />
+              </SettingsRow>
+
+              <SettingsRow label="API Key" hint={editingProvider.apiKeyRef ? "已存储，留空表示不更改" : ""}>
+                <Input.Password
+                  value={apiKeyInput}
+                  placeholder={editingProvider.apiKeyRef ? "留空保留原密钥" : "输入 API Key"}
+                  onChange={(e) => setApiKeyInput(e.target.value)}
+                />
+              </SettingsRow>
+
+              <SettingsSwitchRow
+                label="启用此提供商"
+                checked={editingProvider.enabled}
+                onChange={(v) =>
+                  setEditingProvider({ ...editingProvider, enabled: v })
+                }
+              />
+
+              <Space style={{ marginTop: 8 }}>
+                <Button
+                  type="primary"
+                  onClick={() => void handleSaveProvider()}
+                >
+                  保存
+                </Button>
+                <Button
+                  loading={testing}
+                  onClick={() => void handleTestProvider()}
+                >
+                  测试连接
+                </Button>
+                <Button onClick={() => setEditingProvider(null)}>取消</Button>
+              </Space>
+            </div>
+          )}
+        </SettingsCard>
+      )}
+    </>
+  );
+};

--- a/apps/desktop/src/renderer/components/settings-center/constants.ts
+++ b/apps/desktop/src/renderer/components/settings-center/constants.ts
@@ -14,6 +14,7 @@ export const SECTIONS: Array<{ key: SettingsSection; label: string; icon: string
   { key: "network", label: "网络工具", icon: "ri-route-line" },
   { key: "backup", label: "云存档", icon: "ri-cloud-line" },
   { key: "security", label: "安全与审计", icon: "ri-shield-keyhole-line" },
+  { key: "ai", label: "AI 助手", icon: "ri-robot-2-line" },
   { key: "about", label: "关于", icon: "ri-information-line" },
 ];
 

--- a/apps/desktop/src/renderer/components/settings-center/index.ts
+++ b/apps/desktop/src/renderer/components/settings-center/index.ts
@@ -8,6 +8,7 @@ export { NetworkSection } from "./network-section";
 export { RecycleBinSection } from "./recycle-bin-section";
 export { BackupSection } from "./backup-section";
 export { SecuritySection } from "./security-section";
+export { AiSection } from "./ai-section";
 export { AboutSection } from "./about-section";
 
 export type {

--- a/apps/desktop/src/renderer/components/settings-center/types.ts
+++ b/apps/desktop/src/renderer/components/settings-center/types.ts
@@ -7,6 +7,7 @@ export type SettingsSection =
   | "network"
   | "backup"
   | "security"
+  | "ai"
   | "about";
 
 export type LocalShellMode = "preset" | "custom";

--- a/apps/desktop/src/renderer/store/usePreferencesStore.ts
+++ b/apps/desktop/src/renderer/store/usePreferencesStore.ts
@@ -21,7 +21,8 @@ const clonePreferences = (prefs: AppPreferences): AppPreferences => ({
   backup: { ...prefs.backup },
   window: { ...prefs.window },
   traceroute: { ...prefs.traceroute },
-  audit: { ...prefs.audit }
+  audit: { ...prefs.audit },
+  ai: { ...prefs.ai, providers: prefs.ai.providers.map((p) => ({ ...p })) }
 });
 
 const readLegacyValue = (key: string): string | undefined => {
@@ -156,7 +157,8 @@ export const usePreferencesStore = create<PreferencesState>((set, get) => ({
       backup: { ...prev.backup, ...(patch.backup ?? {}) },
       window: { ...prev.window, ...(patch.window ?? {}) },
       traceroute: { ...prev.traceroute, ...(patch.traceroute ?? {}) },
-      audit: { ...prev.audit, ...(patch.audit ?? {}) }
+      audit: { ...prev.audit, ...(patch.audit ?? {}) },
+      ai: { ...prev.ai, ...(patch.ai ?? {}) }
     };
     set({ preferences: optimistic });
 

--- a/apps/desktop/src/renderer/utils/ai-error-message.ts
+++ b/apps/desktop/src/renderer/utils/ai-error-message.ts
@@ -1,0 +1,42 @@
+const pickRawMessage = (error: unknown): string => {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object") {
+    const data = error as Record<string, unknown>;
+    if (typeof data.error === "string") return data.error;
+    if (typeof data.message === "string") return data.message;
+    if (typeof data.reason === "string") return data.reason;
+  }
+  return "";
+};
+
+const normalize = (value: string): string => {
+  return value.replace(/^Error:\s*/i, "").replace(/\s+/g, " ").trim();
+};
+
+const AI_ERROR_PATTERNS: Array<{ label: string; summary: string; pattern: RegExp }> = [
+  { label: "配置错误", summary: "配置错误", pattern: /base url|model.*不能为空|must.*http|provider .*不能为空|\/chat\/completions|\/v1\/messages|:generatecontent/i },
+  { label: "鉴权失败", summary: "鉴权失败", pattern: /\b401\b|\b403\b|unauthorized|forbidden|invalid api key|incorrect api key|api key|authentication/i },
+  { label: "触发限流", summary: "触发限流", pattern: /\b429\b|rate limit|too many requests|quota/i },
+  { label: "请求超时", summary: "请求超时", pattern: /timed out|timeout|请求超时/i },
+  { label: "服务异常", summary: "服务异常", pattern: /\b5\d\d\b|bad gateway|service unavailable|upstream|overloaded/i },
+];
+
+const classify = (message: string): { label: string; summary: string } | undefined => {
+  return AI_ERROR_PATTERNS.find((item) => item.pattern.test(message));
+};
+
+export const formatAiErrorMessage = (error: unknown, fallback = "AI 请求失败"): string => {
+  const raw = normalize(pickRawMessage(error));
+  if (!raw) return fallback;
+
+  const matched = classify(raw);
+  if (!matched) return raw;
+  return raw.startsWith(`${matched.label}：`) ? raw : `${matched.label}：${raw}`;
+};
+
+export const summarizeAiError = (error: unknown, fallback = "AI 请求失败"): string => {
+  const raw = normalize(pickRawMessage(error));
+  if (!raw) return fallback;
+  return classify(raw)?.summary ?? fallback;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -482,6 +482,7 @@ export interface AppPreferences {
     /** 审计日志保留天数，0 表示永不清理 */
     retentionDays: number;
   };
+  ai: AiPreferences;
 }
 
 export interface AppPreferencesPatch {
@@ -547,6 +548,13 @@ export interface AppPreferencesPatch {
   audit?: {
     enabled?: boolean;
     retentionDays?: number;
+  };
+  ai?: {
+    enabled?: boolean;
+    activeProviderId?: string;
+    providers?: AiProviderConfig[];
+    systemPromptOverride?: string;
+    executionTimeoutSec?: number;
   };
 }
 
@@ -635,6 +643,135 @@ export interface ConnectionImportResult {
   errors: string[];
 }
 
+// ────── AI Assistant ──────
+
+export type AiProviderType = "openai" | "anthropic" | "gemini";
+
+export interface AiProviderConfig {
+  id: string;
+  type: AiProviderType;
+  name: string;
+  baseUrl: string;
+  model: string;
+  /** secret:// 引用，密钥不明文存储 */
+  apiKeyRef?: string;
+  enabled: boolean;
+}
+
+export interface AiPreferences {
+  enabled: boolean;
+  activeProviderId?: string;
+  providers: AiProviderConfig[];
+  systemPromptOverride?: string;
+  /** 命令执行超时（秒） */
+  executionTimeoutSec: number;
+  /** 模型请求超时（秒） */
+  providerRequestTimeoutSec: number;
+  /** 模型请求失败后的最大重试次数 */
+  providerMaxRetries: number;
+}
+
+export type AiChatRole = "user" | "assistant" | "system";
+export type AiMessageKind = "chat" | "execution_result";
+export type AiMessageType = "user_prompt" | "assistant_reply" | "execution_result" | "system_note";
+
+type AiMessageRoleLike = {
+  role: AiChatRole;
+  type?: AiMessageType;
+  kind?: AiMessageKind;
+};
+
+export const resolveAiMessageType = (message: AiMessageRoleLike): AiMessageType => {
+  if (message.type) return message.type;
+  if (message.kind === "execution_result") return "execution_result";
+  if (message.role === "assistant") return "assistant_reply";
+  if (message.role === "system") return "system_note";
+  return "user_prompt";
+};
+
+export const isAiExecutionResultMessage = (message: AiMessageRoleLike): boolean => {
+  return resolveAiMessageType(message) === "execution_result";
+};
+
+export const isAiUserPromptMessage = (message: AiMessageRoleLike): boolean => {
+  return resolveAiMessageType(message) === "user_prompt";
+};
+
+export const isAiAssistantReplyMessage = (message: AiMessageRoleLike): boolean => {
+  return resolveAiMessageType(message) === "assistant_reply";
+};
+
+export const isAiSystemNoteMessage = (message: AiMessageRoleLike): boolean => {
+  return resolveAiMessageType(message) === "system_note";
+};
+
+export const getAiMessageCanonicalRole = (message: AiMessageRoleLike): AiChatRole => {
+  const type = resolveAiMessageType(message);
+  if (type === "assistant_reply") return "assistant";
+  if (type === "user_prompt") return "user";
+  return "system";
+};
+
+export const getAiMessageModelRole = (message: AiMessageRoleLike): AiChatRole => {
+  const type = resolveAiMessageType(message);
+  if (type === "assistant_reply") return "assistant";
+  if (type === "system_note") return "system";
+  return "user";
+};
+
+export interface AiChatMessage {
+  id: string;
+  role: AiChatRole;
+  /** 业务语义字段，前端与历史恢复逻辑应优先使用它判断消息类型 */
+  type: AiMessageType;
+  /** 兼容旧历史结构，新增写入不再依赖该字段 */
+  kind?: AiMessageKind;
+  content: string;
+  timestamp: string;
+  /** 若包含执行计划，存储在此 */
+  plan?: AiExecutionPlan;
+  /** 执行进度快照 */
+  executionProgress?: AiExecutionProgress;
+}
+
+export interface AiExecutionStep {
+  step: number;
+  command: string;
+  description: string;
+  risky: boolean;
+}
+
+export interface AiExecutionPlan {
+  steps: AiExecutionStep[];
+  summary: string;
+}
+
+export type AiStepStatus = "pending" | "running" | "success" | "failed" | "skipped";
+
+export interface AiStepResult {
+  step: number;
+  status: AiStepStatus;
+  output?: string;
+  error?: string;
+}
+
+export interface AiExecutionProgress {
+  planSummary: string;
+  steps: AiStepResult[];
+  currentStep: number;
+  completed: boolean;
+}
+
+export interface AiConversation {
+  id: string;
+  title: string;
+  messages: AiChatMessage[];
+  sessionId?: string;
+  connectionId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export const DEFAULT_APP_PREFERENCES: AppPreferences = {
   transfer: {
     uploadDefaultDir: "~",
@@ -698,6 +835,15 @@ export const DEFAULT_APP_PREFERENCES: AppPreferences = {
   audit: {
     enabled: false,
     retentionDays: 7
+  },
+  ai: {
+    enabled: false,
+    activeProviderId: undefined,
+    providers: [],
+    systemPromptOverride: undefined,
+    executionTimeoutSec: 30,
+    providerRequestTimeoutSec: 30,
+    providerMaxRetries: 1
   }
 };
 

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AiConversation,
   AuditLogRecord,
   BackupArchiveMeta,
   BatchCommandExecutionResult,
@@ -118,6 +119,14 @@ import type {
   UpdateCheckResult,
   PingRequestInput,
   PingResult,
+  AiChatInput,
+  AiApproveInput,
+  AiAbortInput,
+  AiHistoryInput,
+  AiProviderTestInput,
+  AiProviderSetApiKeyInput,
+  AiStreamEvent,
+  AiProgressEvent,
   CloudSyncWorkspaceAddInput,
   CloudSyncWorkspaceUpdateInput,
   CloudSyncWorkspaceRemoveInput,
@@ -336,5 +345,15 @@ export interface NextShellApi {
     restore: (payload: RecycleBinRestoreInput) => Promise<ConnectionProfile | SshKeyProfile>;
     purge: (payload: RecycleBinPurgeInput) => Promise<{ ok: true }>;
     clear: () => Promise<{ ok: true; deleted: number }>;
+  };
+  ai: {
+    chat: (payload: AiChatInput) => Promise<{ conversationId: string }>;
+    approve: (payload: AiApproveInput) => Promise<{ ok: true }>;
+    abort: (payload: AiAbortInput) => Promise<{ ok: true }>;
+    history: (payload?: AiHistoryInput) => Promise<AiConversation[]>;
+    testProvider: (payload: AiProviderTestInput) => Promise<{ ok: boolean; error?: string }>;
+    setApiKey: (payload: AiProviderSetApiKeyInput) => Promise<{ ok: true }>;
+    onStream: (listener: (event: AiStreamEvent) => void) => SessionEventUnsubscribe;
+    onProgress: (listener: (event: AiProgressEvent) => void) => SessionEventUnsubscribe;
   };
 }

--- a/packages/shared/src/channels.ts
+++ b/packages/shared/src/channels.ts
@@ -122,5 +122,15 @@ export const IPCChannel = {
   RecycleBinClear: "nextshell:recycle-bin:clear",
 
   // ── Resource Operations (SSH Key) ──
-  ResourceCopySshKey: "nextshell:resource:copy-ssh-key"
+  ResourceCopySshKey: "nextshell:resource:copy-ssh-key",
+
+  // ── AI Assistant ──
+  AiChat: "nextshell:ai:chat",
+  AiApprove: "nextshell:ai:approve",
+  AiAbort: "nextshell:ai:abort",
+  AiHistory: "nextshell:ai:history",
+  AiProviderTest: "nextshell:ai:provider:test",
+  AiProviderSetApiKey: "nextshell:ai:provider:set-api-key",
+  AiStreamEvent: "nextshell:ai:stream:event",
+  AiProgressEvent: "nextshell:ai:progress:event"
 } as const;

--- a/packages/shared/src/contracts.preferences.test.ts
+++ b/packages/shared/src/contracts.preferences.test.ts
@@ -15,6 +15,8 @@ const assert = (condition: boolean, message: string): void => {
 
   const parsed = appPreferencesSchema.parse({});
   assert(parsed.audit.enabled === false, "audit should default to disabled in schema parsing");
+  assert(parsed.ai.providerRequestTimeoutSec === 30, "ai provider timeout should default to 30 seconds");
+  assert(parsed.ai.providerMaxRetries === 1, "ai provider retries should default to 1");
 })();
 
 (() => {
@@ -52,6 +54,17 @@ const assert = (condition: boolean, message: string): void => {
   });
 
   assert(parsed.success, "appPreferencesPatchSchema should accept workspace layout booleans");
+})();
+
+(() => {
+  const parsed = appPreferencesPatchSchema.safeParse({
+    ai: {
+      providerRequestTimeoutSec: 45,
+      providerMaxRetries: 2
+    }
+  });
+
+  assert(parsed.success, "appPreferencesPatchSchema should accept ai provider runtime settings");
 })();
 
 (() => {

--- a/packages/shared/src/contracts.ts
+++ b/packages/shared/src/contracts.ts
@@ -404,6 +404,8 @@ const localShellSchema = z.object({
   }
 });
 
+export const aiProviderTypeSchema = z.enum(["openai", "anthropic", "gemini"]);
+
 export const appPreferencesSchema = z.object({
   transfer: z.object({
     uploadDefaultDir: z.string().min(1).default(DEFAULT_APP_PREFERENCES.transfer.uploadDefaultDir),
@@ -463,7 +465,24 @@ export const appPreferencesSchema = z.object({
   audit: z.object({
     enabled: z.boolean().default(DEFAULT_APP_PREFERENCES.audit.enabled),
     retentionDays: z.coerce.number().int().min(0).max(365).default(DEFAULT_APP_PREFERENCES.audit.retentionDays)
-  }).default(DEFAULT_APP_PREFERENCES.audit)
+  }).default(DEFAULT_APP_PREFERENCES.audit),
+  ai: z.object({
+    enabled: z.boolean().default(DEFAULT_APP_PREFERENCES.ai.enabled),
+    activeProviderId: z.string().optional(),
+    providers: z.array(z.object({
+      id: z.string(),
+      type: aiProviderTypeSchema,
+      name: z.string(),
+      baseUrl: z.string(),
+      model: z.string(),
+      apiKeyRef: z.string().optional(),
+      enabled: z.boolean()
+    })).default(DEFAULT_APP_PREFERENCES.ai.providers),
+    systemPromptOverride: z.string().optional(),
+    executionTimeoutSec: z.coerce.number().int().min(5).max(300).default(DEFAULT_APP_PREFERENCES.ai.executionTimeoutSec),
+    providerRequestTimeoutSec: z.coerce.number().int().min(5).max(120).default(DEFAULT_APP_PREFERENCES.ai.providerRequestTimeoutSec),
+    providerMaxRetries: z.coerce.number().int().min(0).max(3).default(DEFAULT_APP_PREFERENCES.ai.providerMaxRetries)
+  }).default(DEFAULT_APP_PREFERENCES.ai)
 }).default(DEFAULT_APP_PREFERENCES);
 
 export const appPreferencesPatchSchema = z.object({
@@ -537,6 +556,23 @@ export const appPreferencesPatchSchema = z.object({
   audit: z.object({
     enabled: z.boolean().optional(),
     retentionDays: z.coerce.number().int().min(0).max(365).optional()
+  }).optional(),
+  ai: z.object({
+    enabled: z.boolean().optional(),
+    activeProviderId: z.string().optional(),
+    providers: z.array(z.object({
+      id: z.string(),
+      type: aiProviderTypeSchema,
+      name: z.string(),
+      baseUrl: z.string(),
+      model: z.string(),
+      apiKeyRef: z.string().optional(),
+      enabled: z.boolean()
+    })).optional(),
+    systemPromptOverride: z.string().optional(),
+    executionTimeoutSec: z.coerce.number().int().min(5).max(300).optional(),
+    providerRequestTimeoutSec: z.coerce.number().int().min(5).max(120).optional(),
+    providerMaxRetries: z.coerce.number().int().min(0).max(3).optional()
   }).optional()
 });
 
@@ -1020,3 +1056,75 @@ export type RecycleBinRestoreInput = z.infer<typeof recycleBinRestoreSchema>;
 export type RecycleBinPurgeInput = z.infer<typeof recycleBinPurgeSchema>;
 export type RecycleBinClearInput = z.infer<typeof recycleBinClearSchema>;
 export type ResourceCopySshKeyInput = z.infer<typeof resourceCopySshKeySchema>;
+
+// ─── AI Assistant ────────────────────────────────────────────────────────
+
+export const aiChatSchema = z.object({
+  conversationId: z.string().uuid().optional(),
+  message: z.string().trim().min(1),
+  sessionId: z.string().uuid().optional(),
+  connectionId: z.string().uuid().optional(),
+});
+
+export const aiApproveSchema = z.object({
+  conversationId: z.string().uuid(),
+  plan: z.object({
+    steps: z.array(z.object({
+      step: z.number(),
+      command: z.string(),
+      description: z.string(),
+      risky: z.boolean(),
+    })),
+    summary: z.string(),
+  }).optional(),
+});
+
+export const aiAbortSchema = z.object({
+  conversationId: z.string().uuid(),
+});
+
+export const aiHistorySchema = z.object({
+  connectionId: z.string().uuid().optional(),
+});
+
+export const aiProviderTestSchema = z.object({
+  type: aiProviderTypeSchema,
+  baseUrl: z.string().trim().min(1),
+  model: z.string().trim().min(1),
+  apiKey: z.string().min(1),
+});
+
+export const aiProviderSetApiKeySchema = z.object({
+  providerId: z.string().trim().min(1),
+  apiKey: z.string().min(1),
+});
+
+export type AiChatInput = z.infer<typeof aiChatSchema>;
+export type AiApproveInput = z.infer<typeof aiApproveSchema>;
+export type AiAbortInput = z.infer<typeof aiAbortSchema>;
+export type AiHistoryInput = z.infer<typeof aiHistorySchema>;
+export type AiProviderTestInput = z.infer<typeof aiProviderTestSchema>;
+export type AiProviderSetApiKeyInput = z.infer<typeof aiProviderSetApiKeySchema>;
+
+export interface AiStreamEvent {
+  conversationId: string;
+  type: "token" | "plan" | "done" | "error";
+  token?: string;
+  fullContent?: string;
+  plan?: {
+    steps: Array<{ step: number; command: string; description: string; risky: boolean }>;
+    summary: string;
+  };
+  error?: string;
+}
+
+export interface AiProgressEvent {
+  conversationId: string;
+  type: "step_start" | "step_output" | "step_done" | "all_done" | "analysis_start" | "error";
+  step?: number;
+  command?: string;
+  output?: string;
+  status?: "running" | "success" | "failed";
+  error?: string;
+  summary?: string;
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -465,7 +465,11 @@ const cloneDefaultPreferences = (): AppPreferences => {
     backup: { ...DEFAULT_APP_PREFERENCES_VALUE.backup },
     window: { ...DEFAULT_APP_PREFERENCES_VALUE.window },
     traceroute: { ...DEFAULT_APP_PREFERENCES_VALUE.traceroute },
-    audit: { ...DEFAULT_APP_PREFERENCES_VALUE.audit }
+    audit: { ...DEFAULT_APP_PREFERENCES_VALUE.audit },
+    ai: {
+      ...DEFAULT_APP_PREFERENCES_VALUE.ai,
+      providers: DEFAULT_APP_PREFERENCES_VALUE.ai.providers.map((p) => ({ ...p }))
+    }
   };
 };
 
@@ -736,6 +740,44 @@ const parseAppPreferences = (value: string | null): AppPreferences => {
           parsed.audit.retentionDays <= 365
             ? parsed.audit.retentionDays
             : fallback.audit.retentionDays
+      },
+      ai: {
+        enabled:
+          typeof parsed.ai?.enabled === "boolean"
+            ? parsed.ai.enabled
+            : fallback.ai.enabled,
+        activeProviderId:
+          typeof parsed.ai?.activeProviderId === "string"
+            ? parsed.ai.activeProviderId
+            : fallback.ai.activeProviderId,
+        providers: Array.isArray(parsed.ai?.providers)
+          ? parsed.ai.providers
+          : fallback.ai.providers,
+        systemPromptOverride:
+          typeof parsed.ai?.systemPromptOverride === "string"
+            ? parsed.ai.systemPromptOverride
+            : fallback.ai.systemPromptOverride,
+        executionTimeoutSec:
+          typeof parsed.ai?.executionTimeoutSec === "number" &&
+          Number.isInteger(parsed.ai.executionTimeoutSec) &&
+          parsed.ai.executionTimeoutSec >= 5 &&
+          parsed.ai.executionTimeoutSec <= 300
+            ? parsed.ai.executionTimeoutSec
+            : fallback.ai.executionTimeoutSec,
+        providerRequestTimeoutSec:
+          typeof parsed.ai?.providerRequestTimeoutSec === "number" &&
+          Number.isInteger(parsed.ai.providerRequestTimeoutSec) &&
+          parsed.ai.providerRequestTimeoutSec >= 5 &&
+          parsed.ai.providerRequestTimeoutSec <= 120
+            ? parsed.ai.providerRequestTimeoutSec
+            : fallback.ai.providerRequestTimeoutSec,
+        providerMaxRetries:
+          typeof parsed.ai?.providerMaxRetries === "number" &&
+          Number.isInteger(parsed.ai.providerMaxRetries) &&
+          parsed.ai.providerMaxRetries >= 0 &&
+          parsed.ai.providerMaxRetries <= 3
+            ? parsed.ai.providerMaxRetries
+            : fallback.ai.providerMaxRetries
       }
     };
   } catch {


### PR DESCRIPTION
描述：

  ## 背景

  - 这是对已关闭 PR #21 的重拆版本
  - 目标是先把 AI 的基础类型、IPC 契约、偏好存储和设置入口独立出来，降低后续评审复杂度
  - 建议先审本 PR，再看 #26 和 #27

  ## 本 PR 包含

  - 新增 AI 相关 core types 与执行计划数据结构
  - 新增 AI IPC channels、contracts 与 API 定义
  - 扩展 preferences / storage / preload 链路
  - 接入桌面端 AI 设置入口
  - 新增 AI 提供商配置、API Key 设置、连通性测试等设置页能力
  - 保留当前分支上的设置页精简结果，已去掉“推荐场景”和“当前生效策略”

  ## 主要文件

  - `packages/core/src/index.ts`
  - `packages/shared/src/api.ts`
  - `packages/shared/src/channels.ts`
  - `packages/shared/src/contracts.ts`
  - `packages/storage/src/index.ts`
  - `apps/desktop/src/main/services/preferences.ts`
  - `apps/desktop/src/preload/index.ts`
  - `apps/desktop/src/renderer/components/SettingsCenterModal.tsx`
  - `apps/desktop/src/renderer/components/settings-center/ai-section.tsx`
  - `apps/desktop/src/renderer/store/usePreferencesStore.ts`

  ## 评审建议

  建议重点关注两部分：

  1. AI 核心数据结构和 IPC 契约是否稳定、可扩展
  2. 设置页和偏好链路是否完整闭环

  ## 后续关系

  - #26 会在本 PR 基础上增加主进程 AI 服务与命令执行链路
  - #27 会在前两个 PR 基础上增加 AI Chat 面板与交互体验
