### PR TITLE
feat: add AI service runtime and terminal execution safeguards

### DIFF
--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -103,7 +103,13 @@ import {
   recycleBinListSchema,
   recycleBinRestoreSchema,
   recycleBinPurgeSchema,
-  recycleBinClearSchema
+  recycleBinClearSchema,
+  aiChatSchema,
+  aiApproveSchema,
+  aiAbortSchema,
+  aiHistorySchema,
+  aiProviderTestSchema,
+  aiProviderSetApiKeySchema
 } from "../../../../../packages/shared/src/index";
 import type { ServiceContainer } from "../services/container";
 
@@ -721,5 +727,37 @@ export const registerIpcHandlers = (services: ServiceContainer): void => {
   ipcMain.handle(IPCChannel.RecycleBinClear, (_event, payload) => {
     parsePayload(recycleBinClearSchema, payload ?? {}, "清空回收站");
     return services.recycleBinClear();
+  });
+
+  // ─── AI Assistant ──────────────────────────────────────────────────────────
+
+  ipcMain.handle(IPCChannel.AiChat, (event, payload) => {
+    const input = parsePayload(aiChatSchema, payload, "AI 对话");
+    return services.aiChat(event.sender, input);
+  });
+
+  ipcMain.handle(IPCChannel.AiApprove, (event, payload) => {
+    const input = parsePayload(aiApproveSchema, payload, "AI 批准执行");
+    return services.aiApprove(event.sender, input);
+  });
+
+  ipcMain.handle(IPCChannel.AiAbort, (event, payload) => {
+    const input = parsePayload(aiAbortSchema, payload, "AI 中止");
+    return services.aiAbort(event.sender, input);
+  });
+
+  ipcMain.handle(IPCChannel.AiHistory, (event, payload) => {
+    const input = parsePayload(aiHistorySchema, payload ?? {}, "AI 对话历史");
+    return services.aiHistory(event.sender, input);
+  });
+
+  ipcMain.handle(IPCChannel.AiProviderTest, (_event, payload) => {
+    const input = parsePayload(aiProviderTestSchema, payload, "AI 提供商测试");
+    return services.aiTestProvider(input);
+  });
+
+  ipcMain.handle(IPCChannel.AiProviderSetApiKey, (_event, payload) => {
+    const input = parsePayload(aiProviderSetApiKeySchema, payload, "AI 设置密钥");
+    return services.aiSetApiKey(input);
   });
 };

--- a/apps/desktop/src/main/services/ai/adapters/anthropic-adapter.ts
+++ b/apps/desktop/src/main/services/ai/adapters/anthropic-adapter.ts
@@ -1,0 +1,134 @@
+import type { ChatMessage, LlmAdapter, LlmOptions } from "./types";
+import { fetchWithRetry } from "./request-utils";
+
+interface AnthropicConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+export class AnthropicAdapter implements LlmAdapter {
+  private readonly config: AnthropicConfig;
+  private readonly providerKey: string;
+
+  constructor(config: AnthropicConfig) {
+    this.config = config;
+    this.providerKey = `anthropic:${config.baseUrl}:${config.model}`;
+  }
+
+  private buildPayload(messages: ChatMessage[], options?: LlmOptions, stream = false): {
+    url: string;
+    body: Record<string, unknown>;
+    headers: Record<string, string>;
+  } {
+    const systemMsg = messages.find((m) => m.role === "system");
+    const nonSystemMsgs = messages
+      .filter((m) => m.role !== "system")
+      .map((m) => ({ role: m.role, content: m.content }));
+
+    return {
+      url: `${this.config.baseUrl.replace(/\/+$/, "")}/v1/messages`,
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": this.config.apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: {
+        model: this.config.model,
+        max_tokens: options?.maxTokens ?? 4096,
+        ...(systemMsg ? { system: systemMsg.content } : {}),
+        messages: nonSystemMsgs,
+        stream,
+      },
+    };
+  }
+
+  async chat(messages: ChatMessage[], options?: LlmOptions): Promise<string> {
+    const { url, headers, body } = this.buildPayload(messages, options, false);
+    const response = await fetchWithRetry("Anthropic", url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    }, {
+      signal: options?.signal,
+      timeoutMs: options?.timeoutMs,
+      maxRetries: options?.maxRetries ?? 1,
+      providerKey: options?.providerKey ?? this.providerKey,
+    });
+
+    const data = await response.json() as {
+      content: Array<{ type: string; text?: string }>;
+    };
+    return data.content
+      .filter((b) => b.type === "text")
+      .map((b) => b.text ?? "")
+      .join("");
+  }
+
+  async streamChat(
+    messages: ChatMessage[],
+    onToken: (token: string) => void,
+    options?: LlmOptions
+  ): Promise<string> {
+    const { url, headers, body } = this.buildPayload(messages, options, true);
+    const response = await fetchWithRetry("Anthropic", url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    }, {
+      signal: options?.signal,
+      timeoutMs: options?.timeoutMs,
+      maxRetries: options?.maxRetries ?? 1,
+      providerKey: options?.providerKey ?? this.providerKey,
+    });
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("No response body");
+
+    const decoder = new TextDecoder();
+    let fullContent = "";
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("data: ")) continue;
+        const payload = trimmed.slice(6);
+
+        try {
+          const parsed = JSON.parse(payload) as {
+            type: string;
+            delta?: { type: string; text?: string };
+          };
+          if (parsed.type === "content_block_delta" && parsed.delta?.text) {
+            fullContent += parsed.delta.text;
+            onToken(parsed.delta.text);
+          }
+        } catch {
+          // skip
+        }
+      }
+    }
+
+    return fullContent;
+  }
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const result = await this.chat(
+        [{ role: "user", content: "Reply with OK" }],
+        { maxTokens: 10, timeoutMs: 10_000, maxRetries: 1 }
+      );
+      return { ok: result.length > 0 };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}

--- a/apps/desktop/src/main/services/ai/adapters/gemini-adapter.ts
+++ b/apps/desktop/src/main/services/ai/adapters/gemini-adapter.ts
@@ -1,0 +1,142 @@
+import type { ChatMessage, LlmAdapter, LlmOptions } from "./types";
+import { fetchWithRetry } from "./request-utils";
+
+interface GeminiConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+export class GeminiAdapter implements LlmAdapter {
+  private readonly config: GeminiConfig;
+  private readonly providerKey: string;
+
+  constructor(config: GeminiConfig) {
+    this.config = config;
+    this.providerKey = `gemini:${config.baseUrl}:${config.model}`;
+  }
+
+  private buildContents(messages: ChatMessage[]): {
+    systemInstruction?: { parts: Array<{ text: string }> };
+    contents: Array<{ role: string; parts: Array<{ text: string }> }>;
+  } {
+    const systemMsg = messages.find((m) => m.role === "system");
+    const conversationMsgs = messages.filter((m) => m.role !== "system");
+
+    return {
+      ...(systemMsg ? { systemInstruction: { parts: [{ text: systemMsg.content }] } } : {}),
+      contents: conversationMsgs.map((m) => ({
+        role: m.role === "assistant" ? "model" : "user",
+        parts: [{ text: m.content }],
+      })),
+    };
+  }
+
+  async chat(messages: ChatMessage[], options?: LlmOptions): Promise<string> {
+    const baseUrl = this.config.baseUrl.replace(/\/+$/, "");
+    const url = `${baseUrl}/v1beta/models/${this.config.model}:generateContent?key=${this.config.apiKey}`;
+    const { contents, systemInstruction } = this.buildContents(messages);
+
+    const response = await fetchWithRetry("Gemini", url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents,
+        ...(systemInstruction ? { systemInstruction } : {}),
+        generationConfig: {
+          temperature: options?.temperature ?? 0.7,
+          maxOutputTokens: options?.maxTokens ?? 4096,
+        },
+      }),
+    }, {
+      signal: options?.signal,
+      timeoutMs: options?.timeoutMs,
+      maxRetries: options?.maxRetries ?? 1,
+      providerKey: options?.providerKey ?? this.providerKey,
+    });
+
+    const data = await response.json() as {
+      candidates: Array<{ content: { parts: Array<{ text: string }> } }>;
+    };
+    return data.candidates?.[0]?.content?.parts
+      ?.map((p) => p.text)
+      .join("") ?? "";
+  }
+
+  async streamChat(
+    messages: ChatMessage[],
+    onToken: (token: string) => void,
+    options?: LlmOptions
+  ): Promise<string> {
+    const baseUrl = this.config.baseUrl.replace(/\/+$/, "");
+    const url = `${baseUrl}/v1beta/models/${this.config.model}:streamGenerateContent?key=${this.config.apiKey}&alt=sse`;
+    const { contents, systemInstruction } = this.buildContents(messages);
+
+    const response = await fetchWithRetry("Gemini", url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents,
+        ...(systemInstruction ? { systemInstruction } : {}),
+        generationConfig: {
+          temperature: options?.temperature ?? 0.7,
+          maxOutputTokens: options?.maxTokens ?? 4096,
+        },
+      }),
+    }, {
+      signal: options?.signal,
+      timeoutMs: options?.timeoutMs,
+      maxRetries: options?.maxRetries ?? 1,
+      providerKey: options?.providerKey ?? this.providerKey,
+    });
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("No response body");
+
+    const decoder = new TextDecoder();
+    let fullContent = "";
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("data: ")) continue;
+        const payload = trimmed.slice(6);
+
+        try {
+          const parsed = JSON.parse(payload) as {
+            candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+          };
+          const text = parsed.candidates?.[0]?.content?.parts?.[0]?.text;
+          if (text) {
+            fullContent += text;
+            onToken(text);
+          }
+        } catch {
+          // skip
+        }
+      }
+    }
+
+    return fullContent;
+  }
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const result = await this.chat(
+        [{ role: "user", content: "Reply with OK" }],
+        { maxTokens: 10, timeoutMs: 10_000, maxRetries: 1 }
+      );
+      return { ok: result.length > 0 };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}

--- a/apps/desktop/src/main/services/ai/adapters/openai-adapter.ts
+++ b/apps/desktop/src/main/services/ai/adapters/openai-adapter.ts
@@ -1,0 +1,123 @@
+import type { ChatMessage, LlmAdapter, LlmOptions } from "./types";
+import { fetchWithRetry } from "./request-utils";
+
+interface OpenAiConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+export class OpenAiAdapter implements LlmAdapter {
+  private readonly config: OpenAiConfig;
+  private readonly providerKey: string;
+
+  constructor(config: OpenAiConfig) {
+    this.config = config;
+    this.providerKey = `openai:${config.baseUrl}:${config.model}`;
+  }
+
+  async chat(messages: ChatMessage[], options?: LlmOptions): Promise<string> {
+    const url = `${this.config.baseUrl.replace(/\/+$/, "")}/chat/completions`;
+    const response = await fetchWithRetry("OpenAI", url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${this.config.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.config.model,
+        messages,
+        temperature: options?.temperature ?? 0.7,
+        max_tokens: options?.maxTokens ?? 4096,
+        stream: false,
+      }),
+    }, {
+      signal: options?.signal,
+      timeoutMs: options?.timeoutMs,
+      maxRetries: options?.maxRetries ?? 1,
+      providerKey: options?.providerKey ?? this.providerKey,
+    });
+
+    const data = await response.json() as {
+      choices: Array<{ message: { content: string } }>;
+    };
+    return data.choices[0]?.message?.content ?? "";
+  }
+
+  async streamChat(
+    messages: ChatMessage[],
+    onToken: (token: string) => void,
+    options?: LlmOptions
+  ): Promise<string> {
+    const url = `${this.config.baseUrl.replace(/\/+$/, "")}/chat/completions`;
+    const response = await fetchWithRetry("OpenAI", url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${this.config.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.config.model,
+        messages,
+        temperature: options?.temperature ?? 0.7,
+        max_tokens: options?.maxTokens ?? 4096,
+        stream: true,
+      }),
+    }, {
+      signal: options?.signal,
+      timeoutMs: options?.timeoutMs,
+      maxRetries: options?.maxRetries ?? 1,
+      providerKey: options?.providerKey ?? this.providerKey,
+    });
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("No response body");
+
+    const decoder = new TextDecoder();
+    let fullContent = "";
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith("data: ")) continue;
+        const payload = trimmed.slice(6);
+        if (payload === "[DONE]") continue;
+
+        try {
+          const parsed = JSON.parse(payload) as {
+            choices: Array<{ delta: { content?: string } }>;
+          };
+          const token = parsed.choices[0]?.delta?.content;
+          if (token) {
+            fullContent += token;
+            onToken(token);
+          }
+        } catch {
+          // skip malformed SSE chunks
+        }
+      }
+    }
+
+    return fullContent;
+  }
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const result = await this.chat(
+        [{ role: "user", content: "Reply with OK" }],
+        { maxTokens: 10, timeoutMs: 10_000, maxRetries: 1 }
+      );
+      return { ok: result.length > 0 };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}

--- a/apps/desktop/src/main/services/ai/adapters/request-utils.ts
+++ b/apps/desktop/src/main/services/ai/adapters/request-utils.ts
@@ -1,0 +1,332 @@
+import type { AiProviderType } from "../../../../../../../packages/core/src/index";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_RETRY_DELAY_MS = 400;
+const DEFAULT_MAX_CONCURRENT_REQUESTS = 2;
+const MAX_RETRY_AFTER_MS = 30_000;
+
+export interface ProviderRequestOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  maxRetries?: number;
+  providerKey?: string;
+  maxConcurrentRequests?: number;
+}
+
+export class ProviderCapabilityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProviderCapabilityError";
+  }
+}
+
+export class ProviderHttpError extends Error {
+  readonly status: number;
+  readonly retryable: boolean;
+  readonly retryAfterMs?: number;
+
+  constructor(message: string, status: number, retryable = false, retryAfterMs?: number) {
+    super(message);
+    this.name = "ProviderHttpError";
+    this.status = status;
+    this.retryable = retryable;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+interface ProviderRuntimeState {
+  activeCount: number;
+  nextAllowedAt: number;
+  waiters: Array<() => void>;
+}
+
+const providerRuntimeStates = new Map<string, ProviderRuntimeState>();
+
+const getProviderRuntimeState = (providerKey: string): ProviderRuntimeState => {
+  const existing = providerRuntimeStates.get(providerKey);
+  if (existing) return existing;
+  const created: ProviderRuntimeState = {
+    activeCount: 0,
+    nextAllowedAt: 0,
+    waiters: [],
+  };
+  providerRuntimeStates.set(providerKey, created);
+  return created;
+};
+
+const notifyProviderWaiters = (state: ProviderRuntimeState): void => {
+  const waiters = state.waiters.splice(0, state.waiters.length);
+  for (const wake of waiters) wake();
+};
+
+const sleep = async (ms: number, signal?: AbortSignal): Promise<void> => {
+  if (ms <= 0) return;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+};
+
+const waitForProviderWindow = async (
+  state: ProviderRuntimeState,
+  waitMs: number,
+  signal?: AbortSignal
+): Promise<void> => {
+  await new Promise<void>((resolve, reject) => {
+    let done = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (): void => {
+      if (done) return;
+      done = true;
+      if (timer) clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    };
+
+    const onAbort = (): void => {
+      if (done) return;
+      done = true;
+      if (timer) clearTimeout(timer);
+      state.waiters = state.waiters.filter((wake) => wake !== finish);
+      reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+    };
+
+    if (waitMs > 0) {
+      timer = setTimeout(finish, waitMs);
+    }
+
+    state.waiters.push(finish);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+};
+
+const acquireProviderSlot = async (
+  providerKey: string,
+  signal?: AbortSignal,
+  maxConcurrentRequests = DEFAULT_MAX_CONCURRENT_REQUESTS
+): Promise<() => void> => {
+  const state = getProviderRuntimeState(providerKey);
+
+  while (true) {
+    if (signal?.aborted) {
+      throw signal.reason ?? new DOMException("Aborted", "AbortError");
+    }
+
+    const now = Date.now();
+    const waitMs = Math.max(0, state.nextAllowedAt - now);
+    if (state.activeCount < maxConcurrentRequests && waitMs === 0) {
+      state.activeCount += 1;
+      return () => {
+        state.activeCount = Math.max(0, state.activeCount - 1);
+        notifyProviderWaiters(state);
+      };
+    }
+
+    await waitForProviderWindow(state, waitMs, signal);
+  }
+};
+
+const setProviderBackoff = (providerKey: string, delayMs: number): void => {
+  if (delayMs <= 0) return;
+  const state = getProviderRuntimeState(providerKey);
+  state.nextAllowedAt = Math.max(state.nextAllowedAt, Date.now() + delayMs);
+  notifyProviderWaiters(state);
+};
+
+const createRequestSignal = (
+  sourceSignal?: AbortSignal,
+  timeoutMs = DEFAULT_TIMEOUT_MS
+): { signal: AbortSignal; cleanup: () => void; didTimeout: () => boolean } => {
+  const controller = new AbortController();
+  let timeoutTriggered = false;
+
+  const onAbort = () => {
+    controller.abort(sourceSignal?.reason ?? new DOMException("Aborted", "AbortError"));
+  };
+
+  if (sourceSignal?.aborted) {
+    onAbort();
+  } else {
+    sourceSignal?.addEventListener("abort", onAbort, { once: true });
+  }
+
+  const timer = setTimeout(() => {
+    timeoutTriggered = true;
+    controller.abort(new Error(`AI provider request timed out after ${timeoutMs}ms`));
+  }, timeoutMs);
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      sourceSignal?.removeEventListener("abort", onAbort);
+    },
+    didTimeout: () => timeoutTriggered,
+  };
+};
+
+const shouldRetryStatus = (status: number): boolean => {
+  return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
+};
+
+const readErrorText = async (response: Response): Promise<string> => {
+  const text = await response.text().catch(() => "");
+  return text.length > 300 ? `${text.slice(0, 300)}...` : text;
+};
+
+const parseRetryAfterMs = (value: string | null): number | undefined => {
+  if (!value) return undefined;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS);
+  }
+
+  const dateMs = Date.parse(value);
+  if (Number.isFinite(dateMs)) {
+    return Math.min(Math.max(0, dateMs - Date.now()), MAX_RETRY_AFTER_MS);
+  }
+
+  return undefined;
+};
+
+const getRetryDelayMs = (
+  attempt: number,
+  retryAfterMs?: number
+): number => {
+  if (retryAfterMs !== undefined) return retryAfterMs;
+  return Math.min(DEFAULT_RETRY_DELAY_MS * 2 ** attempt, MAX_RETRY_AFTER_MS);
+};
+
+export const formatProviderTimeoutMessage = (providerLabel: string, timeoutMs: number): string => {
+  return `${providerLabel} 请求超时（${Math.ceil(timeoutMs / 1000)} 秒）`;
+};
+
+export const validateProviderCapability = (
+  type: AiProviderType,
+  baseUrl: string,
+  model: string
+): void => {
+  const normalizedBaseUrl = baseUrl.trim();
+  const normalizedModel = model.trim();
+
+  if (!/^https?:\/\//.test(normalizedBaseUrl)) {
+    throw new ProviderCapabilityError("Provider Base URL 必须以 http:// 或 https:// 开头");
+  }
+
+  if (!normalizedModel) {
+    throw new ProviderCapabilityError("Provider Model 不能为空");
+  }
+
+  const lowerBaseUrl = normalizedBaseUrl.toLowerCase();
+  switch (type) {
+    case "openai":
+      if (lowerBaseUrl.includes("/chat/completions")) {
+        throw new ProviderCapabilityError(
+          "OpenAI Base URL 不应包含 /chat/completions，请填写 API 根地址，例如 https://api.openai.com/v1"
+        );
+      }
+      break;
+    case "anthropic":
+      if (lowerBaseUrl.includes("/v1/messages")) {
+        throw new ProviderCapabilityError(
+          "Anthropic Base URL 不应包含 /v1/messages，请填写 API 根地址，例如 https://api.anthropic.com"
+        );
+      }
+      break;
+    case "gemini":
+      if (lowerBaseUrl.includes("/models/") || lowerBaseUrl.includes(":generatecontent")) {
+        throw new ProviderCapabilityError(
+          "Gemini Base URL 不应包含 /models/... 或 :generateContent，请填写 API 根地址，例如 https://generativelanguage.googleapis.com"
+        );
+      }
+      break;
+  }
+};
+
+export const fetchWithRetry = async (
+  providerLabel: string,
+  input: string,
+  init: RequestInit,
+  options?: ProviderRequestOptions
+): Promise<Response> => {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxRetries = Math.max(0, options?.maxRetries ?? 0);
+  const providerKey = options?.providerKey ?? providerLabel;
+  const maxConcurrentRequests = Math.max(1, options?.maxConcurrentRequests ?? DEFAULT_MAX_CONCURRENT_REQUESTS);
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const requestSignal = createRequestSignal(options?.signal, timeoutMs);
+    const releaseProviderSlot = await acquireProviderSlot(providerKey, options?.signal, maxConcurrentRequests);
+
+    try {
+      const response = await fetch(input, {
+        ...init,
+        signal: requestSignal.signal,
+      });
+
+      if (!response.ok) {
+        const text = await readErrorText(response);
+        const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
+        const message = `${providerLabel} API error ${response.status}${text ? `: ${text}` : ""}`;
+        const error = new ProviderHttpError(
+          message,
+          response.status,
+          shouldRetryStatus(response.status),
+          retryAfterMs
+        );
+        if (error.retryable && attempt < maxRetries) {
+          const delayMs = getRetryDelayMs(attempt, retryAfterMs);
+          setProviderBackoff(providerKey, delayMs);
+          await sleep(delayMs, options?.signal);
+          continue;
+        }
+        throw error;
+      }
+
+      return response;
+    } catch (error) {
+      lastError = error;
+
+      if (requestSignal.didTimeout()) {
+        throw new Error(formatProviderTimeoutMessage(providerLabel, timeoutMs));
+      }
+
+      if (options?.signal?.aborted) {
+        throw error;
+      }
+
+      const retryable =
+        error instanceof ProviderHttpError
+          ? error.retryable
+          : error instanceof TypeError;
+
+      if (!retryable || attempt >= maxRetries) {
+        throw error;
+      }
+
+      const delayMs = getRetryDelayMs(
+        attempt,
+        error instanceof ProviderHttpError ? error.retryAfterMs : undefined
+      );
+      setProviderBackoff(providerKey, delayMs);
+      await sleep(delayMs, options?.signal);
+    } finally {
+      releaseProviderSlot();
+      requestSignal.cleanup();
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(`${providerLabel} 请求失败`);
+};

--- a/apps/desktop/src/main/services/ai/adapters/types.ts
+++ b/apps/desktop/src/main/services/ai/adapters/types.ts
@@ -1,0 +1,23 @@
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface LlmOptions {
+  temperature?: number;
+  maxTokens?: number;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  maxRetries?: number;
+  providerKey?: string;
+}
+
+export interface LlmAdapter {
+  chat(messages: ChatMessage[], options?: LlmOptions): Promise<string>;
+  streamChat(
+    messages: ChatMessage[],
+    onToken: (token: string) => void,
+    options?: LlmOptions
+  ): Promise<string>;
+  testConnection(): Promise<{ ok: boolean; error?: string }>;
+}

--- a/apps/desktop/src/main/services/ai/ai-execution-coordinator.ts
+++ b/apps/desktop/src/main/services/ai/ai-execution-coordinator.ts
@@ -1,0 +1,308 @@
+import crypto from "node:crypto";
+import type { AiExecutionPlan, CommandExecutionResult } from "@nextshell/core";
+import type { AiProgressEvent } from "@nextshell/shared";
+import { sanitizeAiOutput, truncateOutput } from "./output-capture";
+
+export interface AiExecutionCoordinatorDeps {
+  execCommand: (
+    connectionId: string,
+    cmd: string,
+    options?: { signal?: AbortSignal; timeoutMs?: number; skipAudit?: boolean }
+  ) => Promise<CommandExecutionResult>;
+  execInSession?: (
+    sessionId: string,
+    cmd: string,
+    options?: { signal?: AbortSignal; timeoutMs?: number }
+  ) => Promise<CommandExecutionResult>;
+  appendAuditLog: (payload: {
+    action: string;
+    level: "info" | "warn" | "error";
+    connectionId?: string;
+    message: string;
+    metadata?: Record<string, unknown>;
+  }) => void;
+  isAbortError: (error: unknown) => boolean;
+}
+
+export interface AiExecutionStepResult {
+  step: AiExecutionPlan["steps"][number];
+  exitCode: number | null;
+  output: string;
+  sanitizedOutput: string;
+  truncated: ReturnType<typeof truncateOutput>;
+}
+
+export interface ExecuteAiPlanParams {
+  conversationId: string;
+  connectionId: string;
+  sessionId?: string;
+  plan: AiExecutionPlan;
+  timeoutMs: number;
+  signal: AbortSignal;
+  ensureNotAborted: () => void;
+  onProgress: (event: AiProgressEvent) => void;
+  onStepCompleted: (result: AiExecutionStepResult) => void;
+}
+
+export interface ExecuteAiPlanResult {
+  runId: string;
+  status: "completed" | "failed" | "aborted";
+  error?: string;
+}
+
+interface AiExecutionAuditContext {
+  runId: string;
+  conversationId: string;
+  connectionId: string;
+  planSummary: string;
+}
+
+/** 将字符串安全包裹为 shell 单引号参数 */
+const escapeShellArg = (arg: string): string => {
+  return "'" + arg.replace(/'/g, "'\\''") + "'";
+};
+
+export class AiExecutionCoordinator {
+  constructor(private readonly deps: AiExecutionCoordinatorDeps) {}
+
+  async executePlan(params: ExecuteAiPlanParams): Promise<ExecuteAiPlanResult> {
+    const auditContext: AiExecutionAuditContext = {
+      runId: crypto.randomUUID(),
+      conversationId: params.conversationId,
+      connectionId: params.connectionId,
+      planSummary: params.plan.summary,
+    };
+
+    this.appendRunAudit(auditContext, "started", "info", {
+      stepCount: params.plan.steps.length,
+      executionTimeoutMs: params.timeoutMs,
+    });
+
+    try {
+      for (const step of params.plan.steps) {
+        const stepStartedAt = Date.now();
+
+        params.ensureNotAborted();
+        this.appendStepAudit(auditContext, step, "started", "info");
+        params.onProgress({
+          conversationId: params.conversationId,
+          type: "step_start",
+          step: step.step,
+          command: step.command,
+          status: "running",
+        });
+
+        try {
+          const result = await this.executeStepCommand(step.command, params);
+
+          params.ensureNotAborted();
+          const executionResult = this.normalizeStepResult(step, result);
+          params.onProgress({
+            conversationId: params.conversationId,
+            type: "step_output",
+            step: step.step,
+            output: executionResult.output,
+            status: "success",
+          });
+          params.onProgress({
+            conversationId: params.conversationId,
+            type: "step_done",
+            step: step.step,
+            status: executionResult.exitCode === 0 || executionResult.exitCode === null ? "success" : "failed",
+            output: executionResult.output,
+          });
+          params.onStepCompleted(executionResult);
+
+          this.appendStepAudit(
+            auditContext,
+            step,
+            "completed",
+            executionResult.exitCode === 0 || executionResult.exitCode === null ? "info" : "warn",
+            {
+              exitCode: executionResult.exitCode,
+              durationMs: Date.now() - stepStartedAt,
+              outputChars: executionResult.output.length,
+              outputWasTruncated: executionResult.truncated.wasTruncated,
+            }
+          );
+        } catch (error) {
+          if (this.deps.isAbortError(error) || params.signal.aborted) {
+            this.appendStepAudit(auditContext, step, "aborted", "warn", {
+              durationMs: Date.now() - stepStartedAt,
+            });
+            this.appendRunAudit(auditContext, "aborted", "warn", {
+              stepCount: params.plan.steps.length,
+            });
+            return { runId: auditContext.runId, status: "aborted" };
+          }
+
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          this.appendStepAudit(auditContext, step, "failed", "error", {
+            durationMs: Date.now() - stepStartedAt,
+            error: errorMsg,
+          });
+          this.appendRunAudit(auditContext, "failed", "error", {
+            stepCount: params.plan.steps.length,
+            error: errorMsg,
+          });
+          params.onProgress({
+            conversationId: params.conversationId,
+            type: "error",
+            step: step.step,
+            error: errorMsg,
+            status: "failed",
+          });
+          return { runId: auditContext.runId, status: "failed", error: errorMsg };
+        }
+      }
+
+      this.appendRunAudit(auditContext, "completed", "info", {
+        stepCount: params.plan.steps.length,
+      });
+      return { runId: auditContext.runId, status: "completed" };
+    } catch (error) {
+      if (this.deps.isAbortError(error) || params.signal.aborted) {
+        this.appendRunAudit(auditContext, "aborted", "warn", {
+          stepCount: params.plan.steps.length,
+        });
+        return { runId: auditContext.runId, status: "aborted" };
+      }
+
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      this.appendRunAudit(auditContext, "failed", "error", {
+        stepCount: params.plan.steps.length,
+        error: errorMsg,
+      });
+      return { runId: auditContext.runId, status: "failed", error: errorMsg };
+    }
+  }
+
+  private normalizeStepResult(
+    step: AiExecutionPlan["steps"][number],
+    result: CommandExecutionResult
+  ): AiExecutionStepResult {
+    const stdoutLines = result.stdout.split("\n");
+    const EXIT_MARKER = "__NEXTSHELL_EXIT__";
+    let markerIdx = -1;
+    for (let index = stdoutLines.length - 1; index >= 0; index--) {
+      if (stdoutLines[index]!.startsWith(EXIT_MARKER)) {
+        markerIdx = index;
+        break;
+      }
+    }
+
+    let exitCode: number | null = null;
+    if (markerIdx >= 0) {
+      const code = parseInt(stdoutLines[markerIdx]!.slice(EXIT_MARKER.length), 10);
+      exitCode = Number.isFinite(code) ? code : null;
+      stdoutLines.splice(markerIdx, 1);
+    }
+
+    const cleanStdout = stdoutLines.join("\n");
+    const cleanStderr = (result.stderr ?? "")
+      .split("\n")
+      .filter((line) => !line.includes("cannot set terminal process group") && !line.includes("no job control"))
+      .join("\n")
+      .trim();
+    const mergedOutput = cleanStdout + (cleanStderr ? `\n${cleanStderr}` : "");
+    const truncated = truncateOutput(mergedOutput);
+    const displayOutput = mergedOutput.length > 2000
+      ? mergedOutput.slice(0, 1000)
+        + `\n... [省略 ${mergedOutput.length - 2000} 字符] ...\n`
+        + mergedOutput.slice(-1000)
+      : mergedOutput;
+
+    return {
+      step,
+      exitCode,
+      output: displayOutput,
+      sanitizedOutput: sanitizeAiOutput(truncated.text),
+      truncated,
+    };
+  }
+
+  private executeHiddenCommand(
+    connectionId: string,
+    command: string,
+    params: Pick<ExecuteAiPlanParams, "signal" | "timeoutMs">
+  ): Promise<CommandExecutionResult> {
+    const EXIT_MARKER = "__NEXTSHELL_EXIT__";
+    const innerCmd = `${command}; echo "${EXIT_MARKER}$?"`;
+    const wrappedCmd = `bash -lic ${escapeShellArg(innerCmd)}`;
+    return this.deps.execCommand(connectionId, wrappedCmd, {
+      signal: params.signal,
+      timeoutMs: params.timeoutMs,
+      skipAudit: true,
+    });
+  }
+
+  private async executeStepCommand(
+    command: string,
+    params: Pick<ExecuteAiPlanParams, "connectionId" | "sessionId" | "signal" | "timeoutMs">
+  ): Promise<CommandExecutionResult> {
+    if (!params.sessionId || !this.deps.execInSession) {
+      return this.executeHiddenCommand(params.connectionId, command, params);
+    }
+
+    try {
+      return await this.deps.execInSession(params.sessionId, command, {
+        signal: params.signal,
+        timeoutMs: params.timeoutMs,
+      });
+    } catch (error) {
+      if (!this.shouldFallbackToHiddenExecution(error)) {
+        throw error;
+      }
+      return this.executeHiddenCommand(params.connectionId, command, params);
+    }
+  }
+
+  private shouldFallbackToHiddenExecution(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return message === "Session not found" || message === "AI 仅支持在远端终端会话中执行命令";
+  }
+
+  private appendRunAudit(
+    context: AiExecutionAuditContext,
+    phase: "started" | "completed" | "failed" | "aborted",
+    level: "info" | "warn" | "error",
+    metadata?: Record<string, unknown>
+  ): void {
+    this.deps.appendAuditLog({
+      action: "ai.execution.run",
+      level,
+      connectionId: context.connectionId,
+      message: `AI execution ${phase}`,
+      metadata: {
+        runId: context.runId,
+        conversationId: context.conversationId,
+        planSummary: context.planSummary,
+        ...metadata,
+      },
+    });
+  }
+
+  private appendStepAudit(
+    context: AiExecutionAuditContext,
+    step: { step: number; command: string; description: string },
+    phase: "started" | "completed" | "failed" | "aborted",
+    level: "info" | "warn" | "error",
+    metadata?: Record<string, unknown>
+  ): void {
+    this.deps.appendAuditLog({
+      action: "ai.execution.step",
+      level,
+      connectionId: context.connectionId,
+      message: `AI execution step ${phase}`,
+      metadata: {
+        runId: context.runId,
+        conversationId: context.conversationId,
+        planSummary: context.planSummary,
+        step: step.step,
+        command: step.command,
+        description: step.description,
+        ...metadata,
+      },
+    });
+  }
+}

--- a/apps/desktop/src/main/services/ai/ai-service.ts
+++ b/apps/desktop/src/main/services/ai/ai-service.ts
@@ -1,0 +1,762 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import type { WebContents } from "electron";
+import type {
+  AiConversation,
+  AiChatMessage,
+  AiExecutionPlan,
+  AiProviderConfig,
+  AppPreferences,
+  CommandExecutionResult,
+} from "../../../../../../packages/core/src/index";
+import {
+  getAiMessageCanonicalRole,
+  getAiMessageModelRole,
+  isAiAssistantReplyMessage,
+  resolveAiMessageType,
+} from "../../../../../../packages/core/src/index";
+import type {
+  AiChatInput,
+  AiApproveInput,
+  AiAbortInput,
+  AiHistoryInput,
+  AiProviderTestInput,
+  AiStreamEvent,
+  AiProgressEvent,
+} from "../../../../../../packages/shared/src/index";
+import { IPCChannel } from "../../../../../../packages/shared/src/index";
+import type { EncryptedSecretVault } from "../../../../../../packages/security/src/index";
+import type { ChatMessage } from "./adapters/types";
+import { LlmRouter } from "./llm-router";
+import { SYSTEM_PROMPT, buildAnalysisPrompt } from "./prompt-templates";
+import { extractPlanFromResponse } from "./plan-parser";
+import { normalizeApprovedPlan } from "./plan-guard";
+import { AiExecutionCoordinator } from "./ai-execution-coordinator";
+import { logger } from "../../logger";
+
+/**
+ * 估算消息的 token 数（粗略：1 token ≈ 3 中文字符或 4 英文字符）。
+ * 不需要精确，只要能防止明显超限即可。
+ */
+const estimateTokens = (text: string): number => {
+  const cjk = text.match(/[\u4e00-\u9fff\u3000-\u303f\uff00-\uffef]/g)?.length ?? 0;
+  const rest = text.length - cjk;
+  return Math.ceil(cjk / 1.5 + rest / 4);
+};
+
+/** 上下文窗口限制（保守值，给模型输出留空间） */
+const CONTEXT_TOKEN_BUDGET = 24000;
+
+/**
+ * 裁剪对话消息以适应模型上下文窗口：
+ * - 始终保留 system prompt
+ * - 始终保留最新的用户消息
+ * - 从最早的消息开始丢弃，直到总 token 量在预算内
+ * - 丢弃时在开头插入一条摘要提示
+ */
+const trimMessagesForContext = (
+  messages: ChatMessage[],
+  budget = CONTEXT_TOKEN_BUDGET
+): ChatMessage[] => {
+  const totalTokens = messages.reduce((sum, m) => sum + estimateTokens(m.content), 0);
+  if (totalTokens <= budget) return messages;
+
+  const system = messages[0]?.role === "system" ? messages[0] : undefined;
+  const rest = system ? messages.slice(1) : [...messages];
+
+  let currentTokens = system ? estimateTokens(system.content) : 0;
+  const lastMsg = rest[rest.length - 1];
+  if (lastMsg) {
+    currentTokens += estimateTokens(lastMsg.content);
+  }
+
+  const kept: ChatMessage[] = [];
+  let droppedCount = 0;
+
+  for (let i = rest.length - 2; i >= 0; i--) {
+    const msg = rest[i]!;
+    const msgTokens = estimateTokens(msg.content);
+    if (currentTokens + msgTokens <= budget - 200) {
+      kept.unshift(msg);
+      currentTokens += msgTokens;
+    } else {
+      droppedCount = i + 1;
+      break;
+    }
+  }
+
+  const result: ChatMessage[] = [];
+  if (system) result.push(system);
+
+  if (droppedCount > 0) {
+    result.push({
+      role: "system",
+      content: `[上下文管理] 为避免超出模型上下文窗口，已省略最早的 ${droppedCount} 条消息。请基于保留的上下文继续分析。`,
+    });
+  }
+
+  result.push(...kept);
+  if (lastMsg) result.push(lastMsg);
+
+  return result;
+};
+
+class AiTaskAbortedError extends Error {
+  constructor(message = "AI 执行已中止") {
+    super(message);
+    this.name = "AiTaskAbortedError";
+  }
+}
+
+const AI_HISTORY_FILE = "ai-conversations.json";
+const MAX_HISTORY_ITEMS = 100;
+
+interface AiTaskContext {
+  chatController?: AbortController;
+  executionController?: AbortController;
+  analysisController?: AbortController;
+  aborted: boolean;
+}
+
+interface AiServiceDeps {
+  execCommand: (
+    connectionId: string,
+    cmd: string,
+    options?: { signal?: AbortSignal; timeoutMs?: number; skipAudit?: boolean }
+  ) => Promise<CommandExecutionResult>;
+  execInSession: (
+    sessionId: string,
+    cmd: string,
+    options?: { signal?: AbortSignal; timeoutMs?: number }
+  ) => Promise<CommandExecutionResult>;
+  vault: EncryptedSecretVault;
+  getPreferences: () => AppPreferences;
+  dataDir: string;
+  appendAuditLog: (payload: {
+    action: string;
+    level: "info" | "warn" | "error";
+    connectionId?: string;
+    message: string;
+    metadata?: Record<string, unknown>;
+  }) => void;
+}
+
+interface ProviderRuntimeOptions {
+  timeoutMs: number;
+  maxRetries: number;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null;
+};
+
+const normalizeLoadedPlan = (value: unknown): AiExecutionPlan | undefined => {
+  if (!isRecord(value) || typeof value.summary !== "string" || !Array.isArray(value.steps)) {
+    return undefined;
+  }
+
+  const steps = value.steps
+    .map((step): AiExecutionPlan["steps"][number] | undefined => {
+      if (!isRecord(step)) return undefined;
+      if (
+        typeof step.step !== "number" ||
+        typeof step.command !== "string" ||
+        typeof step.description !== "string" ||
+        typeof step.risky !== "boolean"
+      ) {
+        return undefined;
+      }
+      return {
+        step: step.step,
+        command: step.command,
+        description: step.description,
+        risky: step.risky,
+      };
+    })
+    .filter((step): step is AiExecutionPlan["steps"][number] => Boolean(step));
+
+  return { summary: value.summary, steps };
+};
+
+const normalizeLoadedMessage = (value: unknown): AiChatMessage | undefined => {
+  if (!isRecord(value)) return undefined;
+  if (
+    typeof value.id !== "string" ||
+    typeof value.content !== "string" ||
+    typeof value.timestamp !== "string" ||
+    (value.role !== "user" && value.role !== "assistant" && value.role !== "system")
+  ) {
+    return undefined;
+  }
+
+  const type = resolveAiMessageType({
+    role: value.role,
+    type:
+      value.type === "user_prompt" ||
+      value.type === "assistant_reply" ||
+      value.type === "execution_result" ||
+      value.type === "system_note"
+        ? value.type
+        : undefined,
+    kind: value.kind === "execution_result" ? "execution_result" : "chat",
+  });
+
+  return {
+    id: value.id,
+    role: getAiMessageCanonicalRole({ role: value.role, type }),
+    type,
+    content: value.content,
+    timestamp: value.timestamp,
+    plan: normalizeLoadedPlan(value.plan),
+  };
+};
+
+const normalizeLoadedConversation = (value: unknown): AiConversation | undefined => {
+  if (!isRecord(value)) return undefined;
+  if (
+    typeof value.id !== "string" ||
+    typeof value.title !== "string" ||
+    typeof value.createdAt !== "string" ||
+    typeof value.updatedAt !== "string" ||
+    !Array.isArray(value.messages)
+  ) {
+    return undefined;
+  }
+
+  return {
+    id: value.id,
+    title: value.title,
+    messages: value.messages
+      .map((message) => normalizeLoadedMessage(message))
+      .filter((message): message is AiChatMessage => Boolean(message)),
+    sessionId: typeof value.sessionId === "string" ? value.sessionId : undefined,
+    connectionId: typeof value.connectionId === "string" ? value.connectionId : undefined,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+  };
+};
+
+export class AiService {
+  private readonly deps: AiServiceDeps;
+  private readonly router = new LlmRouter();
+  private readonly executionCoordinator: AiExecutionCoordinator;
+  private readonly conversations = new Map<string, AiConversation>();
+  private readonly conversationOwners = new Map<string, WebContents>();
+  private readonly apiKeys = new Map<string, string>();
+  private readonly taskContexts = new Map<string, AiTaskContext>();
+  private readonly historyFilePath: string;
+  private persistQueue: Promise<void> = Promise.resolve();
+
+  constructor(deps: AiServiceDeps) {
+    this.deps = deps;
+    this.executionCoordinator = new AiExecutionCoordinator({
+      execCommand: deps.execCommand,
+      execInSession: deps.execInSession,
+      appendAuditLog: deps.appendAuditLog,
+      isAbortError: (error) => this.isAbortError(error),
+    });
+    this.historyFilePath = path.join(deps.dataDir, AI_HISTORY_FILE);
+    this.loadPersistedConversations();
+  }
+
+  private loadPersistedConversations(): void {
+    try {
+      const raw = fs.readFileSync(this.historyFilePath, "utf-8");
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        throw new Error("历史文件格式不正确");
+      }
+
+      for (const item of parsed) {
+        const conversation = normalizeLoadedConversation(item);
+        if (conversation) {
+          this.conversations.set(conversation.id, conversation);
+        }
+      }
+    } catch (error) {
+      const nodeError = error as NodeJS.ErrnoException;
+      if (nodeError?.code !== "ENOENT") {
+        logger.warn("[AI] 加载历史会话失败，已降级为空历史", error);
+      }
+    }
+  }
+
+  private getConversationOwner(conversationId: string): WebContents | undefined {
+    const owner = this.conversationOwners.get(conversationId);
+    if (owner?.isDestroyed()) {
+      this.conversationOwners.delete(conversationId);
+      return undefined;
+    }
+    return owner;
+  }
+
+  private bindConversationOwner(conversationId: string, sender: WebContents): void {
+    if (!sender.isDestroyed()) {
+      this.conversationOwners.set(conversationId, sender);
+    }
+  }
+
+  private canAccessConversation(
+    conversation: AiConversation,
+    sender: WebContents,
+    connectionId?: string
+  ): boolean {
+    const owner = this.getConversationOwner(conversation.id);
+    if (owner) {
+      return owner.id === sender.id;
+    }
+    return Boolean(connectionId && conversation.connectionId === connectionId);
+  }
+
+  private emitToSender(sender: WebContents, channel: string, payload: unknown): void {
+    if (!sender.isDestroyed()) {
+      sender.send(channel, payload);
+    }
+  }
+
+  private queuePersist(): void {
+    const content = JSON.stringify(
+      Array.from(this.conversations.values())
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+        .slice(0, MAX_HISTORY_ITEMS),
+      null,
+      2
+    );
+
+    this.persistQueue = this.persistQueue
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          await fsp.mkdir(path.dirname(this.historyFilePath), { recursive: true });
+          const tempPath = `${this.historyFilePath}.tmp`;
+          await fsp.writeFile(tempPath, content, "utf-8");
+          await fsp.rename(tempPath, this.historyFilePath);
+        } catch (error) {
+          logger.error("[AI] 持久化历史会话失败", error);
+        }
+      });
+  }
+
+  private getTaskContext(conversationId: string): AiTaskContext {
+    const existing = this.taskContexts.get(conversationId);
+    if (existing) {
+      return existing;
+    }
+    const created: AiTaskContext = { aborted: false };
+    this.taskContexts.set(conversationId, created);
+    return created;
+  }
+
+  private resetTaskContext(conversationId: string): AiTaskContext {
+    const current = this.getTaskContext(conversationId);
+    current.chatController?.abort(new AiTaskAbortedError());
+    current.executionController?.abort(new AiTaskAbortedError());
+    current.analysisController?.abort(new AiTaskAbortedError());
+    const next: AiTaskContext = { aborted: false };
+    this.taskContexts.set(conversationId, next);
+    return next;
+  }
+
+  private ensureTaskNotAborted(conversationId: string): void {
+    if (this.taskContexts.get(conversationId)?.aborted) {
+      throw new AiTaskAbortedError();
+    }
+  }
+
+  private isAbortError(error: unknown): boolean {
+    if (error instanceof AiTaskAbortedError) {
+      return true;
+    }
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return true;
+    }
+    return error instanceof Error && error.name === "AbortError";
+  }
+
+  private getActiveProvider(): AiProviderConfig | undefined {
+    const prefs = this.deps.getPreferences();
+    if (!prefs.ai.enabled) return undefined;
+    const activeId = prefs.ai.activeProviderId;
+    return prefs.ai.providers.find((p) => p.id === activeId && p.enabled);
+  }
+
+  private getProviderRuntimeOptions(): ProviderRuntimeOptions {
+    const prefs = this.deps.getPreferences();
+    return {
+      timeoutMs: (prefs.ai.providerRequestTimeoutSec ?? 30) * 1000,
+      maxRetries: prefs.ai.providerMaxRetries ?? 1,
+    };
+  }
+
+  private async resolveApiKey(provider: AiProviderConfig): Promise<string> {
+    const cached = this.apiKeys.get(provider.id);
+    if (cached) return cached;
+
+    if (provider.apiKeyRef) {
+      try {
+        const key = await this.deps.vault.readCredential(provider.apiKeyRef);
+        if (!key) throw new Error("API Key 为空");
+        this.apiKeys.set(provider.id, key);
+        return key;
+      } catch {
+        throw new Error("无法读取 API Key，请在设置中重新配置");
+      }
+    }
+    throw new Error("未配置 API Key，请在设置中添加");
+  }
+
+  async setApiKey(providerId: string, apiKey: string): Promise<void> {
+    const ref = `ai-provider-${providerId}`;
+    await this.deps.vault.storeCredential(ref, apiKey);
+    this.apiKeys.set(providerId, apiKey);
+    this.router.clearCache();
+  }
+
+  async chat(sender: WebContents, input: AiChatInput): Promise<{ conversationId: string }> {
+    const provider = this.getActiveProvider();
+    if (!provider) throw new Error("未启用 AI 助手或未配置提供商");
+
+    const apiKey = await this.resolveApiKey(provider);
+    const adapter = this.router.getAdapter(provider, apiKey);
+    const providerRuntimeOptions = this.getProviderRuntimeOptions();
+
+    let conversation = input.conversationId
+      ? this.conversations.get(input.conversationId)
+      : undefined;
+
+    if (!conversation) {
+      const id = input.conversationId ?? crypto.randomUUID();
+      conversation = {
+        id,
+        title: input.message.slice(0, 50),
+        messages: [],
+        sessionId: input.sessionId,
+        connectionId: input.connectionId,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      this.conversations.set(id, conversation);
+    } else {
+      // 同步最新的 session/connection（用户可能重连或切换了终端 tab）
+      conversation.sessionId = input.sessionId;
+      conversation.connectionId = input.connectionId;
+    }
+
+    this.bindConversationOwner(conversation.id, sender);
+
+    const userMessage: AiChatMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      type: "user_prompt",
+      content: input.message,
+      timestamp: new Date().toISOString(),
+    };
+    conversation.messages.push(userMessage);
+    conversation.updatedAt = userMessage.timestamp;
+    this.queuePersist();
+
+    const prefs = this.deps.getPreferences();
+    const systemPrompt = prefs.ai.systemPromptOverride?.trim() || SYSTEM_PROMPT;
+
+    const chatMessages = trimMessagesForContext([
+      { role: "system", content: systemPrompt },
+      ...conversation.messages.map((m) => ({
+        role: getAiMessageModelRole(m) as "user" | "assistant" | "system",
+        content: m.content,
+      })),
+    ]);
+
+    const conversationId = conversation.id;
+    const taskContext = this.resetTaskContext(conversationId);
+    const chatController = new AbortController();
+    taskContext.chatController = chatController;
+
+    // Stream in background
+    void (async () => {
+      let fullContent = "";
+      try {
+        fullContent = await adapter.streamChat(
+          chatMessages,
+          (token) => {
+            const event: AiStreamEvent = {
+              conversationId,
+              type: "token",
+              token,
+            };
+            this.emitToSender(sender, IPCChannel.AiStreamEvent, event);
+          },
+          {
+            signal: chatController.signal,
+            timeoutMs: providerRuntimeOptions.timeoutMs,
+            maxRetries: providerRuntimeOptions.maxRetries,
+          }
+        );
+
+        const plan = extractPlanFromResponse(fullContent);
+
+        const assistantMessage: AiChatMessage = {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          type: "assistant_reply",
+          content: fullContent,
+          timestamp: new Date().toISOString(),
+          plan: plan ?? undefined,
+        };
+        conversation!.messages.push(assistantMessage);
+        conversation!.updatedAt = assistantMessage.timestamp;
+        this.queuePersist();
+
+        const doneEvent: AiStreamEvent = {
+          conversationId,
+          type: plan ? "plan" : "done",
+          fullContent,
+          ...(plan ? { plan } : {}),
+        };
+        this.emitToSender(sender, IPCChannel.AiStreamEvent, doneEvent);
+      } catch (err) {
+        if (this.isAbortError(err) || chatController.signal.aborted) {
+          return;
+        }
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        logger.error("[AI] chat error", err);
+        const errorEvent: AiStreamEvent = {
+          conversationId,
+          type: "error",
+          error: errorMsg,
+        };
+        this.emitToSender(sender, IPCChannel.AiStreamEvent, errorEvent);
+      } finally {
+        const currentTask = this.taskContexts.get(conversationId);
+        if (currentTask?.chatController === chatController) {
+          currentTask.chatController = undefined;
+        }
+      }
+    })();
+
+    return { conversationId };
+  }
+
+  async approve(sender: WebContents, input: AiApproveInput): Promise<{ ok: true }> {
+    const conversation = this.conversations.get(input.conversationId);
+    if (!conversation) throw new Error("对话不存在");
+    this.bindConversationOwner(conversation.id, sender);
+
+    let planToExecute = input.plan;
+
+    if (!planToExecute) {
+      const lastAssistant = [...conversation.messages]
+        .reverse()
+        .find((m) => isAiAssistantReplyMessage(m) && m.plan);
+      if (!lastAssistant?.plan) throw new Error("没有待执行的计划");
+      planToExecute = lastAssistant.plan;
+    }
+
+    planToExecute = normalizeApprovedPlan(planToExecute);
+
+    const connectionId = conversation.connectionId;
+    if (!connectionId) throw new Error("没有关联的远端连接");
+
+    void this.executePlan(sender, conversation, planToExecute, connectionId);
+
+    return { ok: true as const };
+  }
+
+  private async executePlan(
+    sender: WebContents,
+    conversation: AiConversation,
+    plan: AiExecutionPlan,
+    connectionId: string
+  ): Promise<void> {
+    const conversationId = conversation.id;
+    const prefs = this.deps.getPreferences();
+    const timeoutMs = (prefs.ai.executionTimeoutSec ?? 30) * 1000;
+    const taskContext = this.getTaskContext(conversationId);
+    taskContext.aborted = false;
+    const executionController = new AbortController();
+    taskContext.executionController = executionController;
+
+    try {
+      const executionResult = await this.executionCoordinator.executePlan({
+        conversationId,
+        connectionId,
+        sessionId: conversation.sessionId,
+        plan,
+        timeoutMs,
+        signal: executionController.signal,
+        ensureNotAborted: () => this.ensureTaskNotAborted(conversationId),
+        onProgress: (event) => this.emitToSender(sender, IPCChannel.AiProgressEvent, event),
+        onStepCompleted: ({ step, exitCode, output, sanitizedOutput, truncated }) => {
+          const resultMessage: AiChatMessage = {
+            id: crypto.randomUUID(),
+            role: "system",
+            type: "execution_result",
+            content: buildAnalysisPrompt({
+              command: step.command,
+              output: sanitizedOutput,
+              exitCode,
+              wasTruncated: truncated.wasTruncated,
+              totalLines: truncated.totalLines,
+              totalChars: truncated.totalChars,
+            }),
+            timestamp: new Date().toISOString(),
+          };
+          conversation.messages.push(resultMessage);
+          conversation.updatedAt = resultMessage.timestamp;
+          this.queuePersist();
+        },
+      });
+
+      if (executionResult.status === "aborted") {
+        return;
+      }
+      if (executionResult.status === "failed") {
+        if (executionResult.error) {
+          logger.error("[AI] execution run failed", executionResult.error);
+        }
+        return;
+      }
+
+      this.ensureTaskNotAborted(conversationId);
+
+      const analysisStartEvent: AiProgressEvent = {
+        conversationId,
+        type: "analysis_start",
+        status: "running",
+      };
+      this.emitToSender(sender, IPCChannel.AiProgressEvent, analysisStartEvent);
+
+      const provider = this.getActiveProvider();
+      if (provider) {
+        const apiKey = await this.resolveApiKey(provider);
+        const adapter = this.router.getAdapter(provider, apiKey);
+        const providerRuntimeOptions = this.getProviderRuntimeOptions();
+
+        const prefs = this.deps.getPreferences();
+        const systemPrompt = prefs.ai.systemPromptOverride?.trim() || SYSTEM_PROMPT;
+
+        const chatMessages = trimMessagesForContext([
+          { role: "system", content: systemPrompt },
+          ...conversation.messages.map((m) => ({
+            role: getAiMessageModelRole(m) as "user" | "assistant" | "system",
+            content: m.content,
+          })),
+        ]);
+
+        const analysisController = new AbortController();
+        taskContext.analysisController = analysisController;
+
+        const analysis = await adapter.streamChat(
+          chatMessages,
+          (token) => {
+            this.emitToSender(sender, IPCChannel.AiStreamEvent, {
+              conversationId,
+              type: "token",
+              token,
+            } satisfies AiStreamEvent);
+          },
+          {
+            signal: analysisController.signal,
+            timeoutMs: providerRuntimeOptions.timeoutMs,
+            maxRetries: providerRuntimeOptions.maxRetries,
+          }
+        );
+
+        this.ensureTaskNotAborted(conversationId);
+
+        const newPlan = extractPlanFromResponse(analysis);
+        const analysisMsg: AiChatMessage = {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          type: "assistant_reply",
+          content: analysis,
+          timestamp: new Date().toISOString(),
+          plan: newPlan ?? undefined,
+        };
+        conversation.messages.push(analysisMsg);
+        conversation.updatedAt = analysisMsg.timestamp;
+        this.queuePersist();
+
+        this.emitToSender(sender, IPCChannel.AiStreamEvent, {
+          conversationId,
+          type: newPlan ? "plan" : "done",
+          fullContent: analysis,
+          ...(newPlan ? { plan: newPlan } : {}),
+        } satisfies AiStreamEvent);
+      }
+
+      const allDoneEvent: AiProgressEvent = {
+        conversationId,
+        type: "all_done",
+        summary: plan.summary,
+      };
+      this.emitToSender(sender, IPCChannel.AiProgressEvent, allDoneEvent);
+    } catch (err) {
+      if (this.isAbortError(err)) {
+        return;
+      }
+      logger.error("[AI] post-execution analysis failed", err);
+    } finally {
+      const currentTask = this.taskContexts.get(conversationId);
+      if (currentTask === taskContext) {
+        currentTask.executionController = undefined;
+        currentTask.analysisController = undefined;
+        if (!currentTask.aborted) {
+          this.taskContexts.delete(conversationId);
+        }
+      }
+    }
+  }
+
+  abort(sender: WebContents, input: AiAbortInput): { ok: true } {
+    this.bindConversationOwner(input.conversationId, sender);
+    const context = this.taskContexts.get(input.conversationId);
+    if (context) {
+      context.aborted = true;
+      context.chatController?.abort(new AiTaskAbortedError());
+      context.executionController?.abort(new AiTaskAbortedError());
+      context.analysisController?.abort(new AiTaskAbortedError());
+    }
+    return { ok: true as const };
+  }
+
+  history(sender: WebContents, input: AiHistoryInput): AiConversation[] {
+    const connectionId = input.connectionId;
+    const visible = Array.from(this.conversations.values()).filter((conversation) =>
+      this.canAccessConversation(conversation, sender, connectionId)
+    );
+
+    for (const conversation of visible) {
+      this.bindConversationOwner(conversation.id, sender);
+    }
+
+    return visible
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .slice(0, 50);
+  }
+
+  async testProvider(input: AiProviderTestInput): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const adapter = this.router.createTemporary(
+        input.type,
+        input.baseUrl,
+        input.model,
+        input.apiKey
+      );
+      return await adapter.testConnection();
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  dispose(): void {
+    for (const context of this.taskContexts.values()) {
+      context.chatController?.abort(new AiTaskAbortedError());
+      context.executionController?.abort(new AiTaskAbortedError());
+      context.analysisController?.abort(new AiTaskAbortedError());
+    }
+    this.taskContexts.clear();
+    this.conversationOwners.clear();
+    this.router.clearCache();
+  }
+}

--- a/apps/desktop/src/main/services/ai/llm-router.ts
+++ b/apps/desktop/src/main/services/ai/llm-router.ts
@@ -1,0 +1,52 @@
+import type { AiProviderConfig, AiProviderType } from "../../../../../../packages/core/src/index";
+import type { LlmAdapter } from "./adapters/types";
+import { OpenAiAdapter } from "./adapters/openai-adapter";
+import { AnthropicAdapter } from "./adapters/anthropic-adapter";
+import { GeminiAdapter } from "./adapters/gemini-adapter";
+import { validateProviderCapability } from "./adapters/request-utils";
+
+const createAdapter = (type: AiProviderType, baseUrl: string, model: string, apiKey: string): LlmAdapter => {
+  const normalizedBaseUrl = baseUrl.trim();
+  const normalizedModel = model.trim();
+  validateProviderCapability(type, normalizedBaseUrl, normalizedModel);
+
+  switch (type) {
+    case "openai":
+      return new OpenAiAdapter({ baseUrl: normalizedBaseUrl, apiKey, model: normalizedModel });
+    case "anthropic":
+      return new AnthropicAdapter({ baseUrl: normalizedBaseUrl, apiKey, model: normalizedModel });
+    case "gemini":
+      return new GeminiAdapter({ baseUrl: normalizedBaseUrl, apiKey, model: normalizedModel });
+  }
+};
+
+export class LlmRouter {
+  private cache = new Map<string, LlmAdapter>();
+
+  getAdapter(
+    provider: AiProviderConfig,
+    apiKey: string
+  ): LlmAdapter {
+    const cacheKey = `${provider.id}:${provider.type}:${provider.baseUrl}:${provider.model}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached) return cached;
+
+    const adapter = createAdapter(provider.type, provider.baseUrl, provider.model, apiKey);
+    this.cache.set(cacheKey, adapter);
+    return adapter;
+  }
+
+  /** 用于测试连接时创建临时适配器，不缓存 */
+  createTemporary(
+    type: AiProviderType,
+    baseUrl: string,
+    model: string,
+    apiKey: string
+  ): LlmAdapter {
+    return createAdapter(type, baseUrl, model, apiKey);
+  }
+
+  clearCache(): void {
+    this.cache.clear();
+  }
+}

--- a/apps/desktop/src/main/services/ai/output-capture.ts
+++ b/apps/desktop/src/main/services/ai/output-capture.ts
@@ -1,0 +1,154 @@
+/** 单次提交给 LLM 分析的最大字符数（留余量给 system prompt 和历史消息） */
+const LLM_OUTPUT_LIMIT = 6000;
+/** 超长输出时，头部保留的行数 */
+const HEAD_LINES = 30;
+/** 超长输出时，尾部保留的行数 */
+const TAIL_LINES = 50;
+
+export interface TruncatedOutput {
+  /** 处理后的文本，可直接嵌入 prompt */
+  text: string;
+  /** 原始总行数 */
+  totalLines: number;
+  /** 原始总字符数 */
+  totalChars: number;
+  /** 是否被截断过 */
+  wasTruncated: boolean;
+}
+
+/**
+ * 智能压缩命令输出：
+ * 1. 短输出（≤ LLM_OUTPUT_LIMIT）直接返回
+ * 2. 超长输出：保留头部 + 尾部（错误信息通常在末尾），中间用省略标记
+ * 3. 如果头部+尾部仍然超限，按字符截断尾部
+ */
+export const truncateOutput = (raw: string, limit = LLM_OUTPUT_LIMIT): TruncatedOutput => {
+  const totalChars = raw.length;
+  const lines = raw.split("\n");
+  const totalLines = lines.length;
+
+  if (totalChars <= limit) {
+    return { text: raw, totalLines, totalChars, wasTruncated: false };
+  }
+
+  const headPart = lines.slice(0, HEAD_LINES);
+  const tailPart = lines.slice(-TAIL_LINES);
+  const omitted = totalLines - HEAD_LINES - TAIL_LINES;
+
+  const marker = `\n... [省略中间 ${omitted} 行，共 ${totalLines} 行 / ${totalChars} 字符] ...\n`;
+  let combined = headPart.join("\n") + marker + tailPart.join("\n");
+
+  if (combined.length > limit) {
+    const halfLimit = Math.floor((limit - marker.length) / 2);
+    const headText = headPart.join("\n").slice(0, halfLimit);
+    const tailText = tailPart.join("\n").slice(-halfLimit);
+    combined = headText + marker + tailText;
+  }
+
+  return { text: combined, totalLines, totalChars, wasTruncated: true };
+};
+
+const PARTIAL_MASK = "****";
+
+const maskKeepEdges = (value: string, prefixLength = 4, suffixLength = 4): string => {
+  if (value.length <= prefixLength + suffixLength) {
+    return PARTIAL_MASK;
+  }
+  return `${value.slice(0, prefixLength)}${PARTIAL_MASK}${value.slice(-suffixLength)}`;
+};
+
+/**
+ * 脱敏 AI 分析前的命令输出，避免把常见密钥或口令原样发给外部模型。
+ */
+export const sanitizeAiOutput = (raw: string): string => {
+  return raw
+    .replace(
+      /(authorization\s*:\s*bearer\s+)([^\s]+)/gi,
+      (_match, prefix: string, token: string) => `${prefix}${maskKeepEdges(token)}`
+    )
+    .replace(
+      /((?:token|password|passwd|pwd|apikey|api_key)\s*[:=]\s*)([^\s"'`]+)/gi,
+      (_match, prefix: string, secret: string) => `${prefix}${maskKeepEdges(secret)}`
+    )
+    .replace(
+      /((?:OPENAI|ANTHROPIC|GEMINI)_[A-Z_]*KEY\s*[:=]\s*)([^\s"'`]+)/g,
+      (_match, prefix: string, secret: string) => `${prefix}${maskKeepEdges(secret)}`
+    )
+    .replace(
+      /(-----BEGIN [A-Z ]*PRIVATE KEY-----)([\s\S]*?)(-----END [A-Z ]*PRIVATE KEY-----)/g,
+      (_match, begin: string, _body: string, end: string) => `${begin}\n${PARTIAL_MASK}\n${end}`
+    );
+};
+
+/**
+ * 去除 ANSI 控制序列，保留纯文本内容。
+ */
+export const stripAnsi = (text: string): string => {
+  // ESC[ ... m  (SGR), ESC[ ... 其它, OSC sequences, 以及其它常见序列
+  return text
+    .replace(/\x1B\[[0-9;]*[a-zA-Z]/g, "")
+    .replace(/\x1B\][^\x07]*\x07/g, "")
+    .replace(/\x1B\(B/g, "")
+    .replace(/\r/g, "");
+};
+
+/**
+ * 从终端输出中检测 shell prompt，判断命令是否执行完毕。
+ * 常见 prompt 模式：`$`, `#`, `>`, `%` 在行尾。
+ */
+export const detectPromptEnd = (text: string): boolean => {
+  const lines = text.split("\n").filter((l) => l.trim().length > 0);
+  if (lines.length === 0) return false;
+
+  const lastLine = lines[lines.length - 1]?.trim() ?? "";
+  return /[$#%>]\s*$/.test(lastLine);
+};
+
+/**
+ * 终端输出聚合器：收集一段时间内的输出，
+ * 直到检测到 prompt 或超时。
+ */
+export class OutputCollector {
+  private chunks: string[] = [];
+  private resolve?: (output: string) => void;
+  private timeoutId?: ReturnType<typeof setTimeout>;
+  private promptCheckId?: ReturnType<typeof setInterval>;
+
+  collect(timeoutMs: number): Promise<string> {
+    return new Promise<string>((resolve) => {
+      this.resolve = resolve;
+
+      this.timeoutId = setTimeout(() => {
+        this.finish();
+      }, timeoutMs);
+
+      this.promptCheckId = setInterval(() => {
+        const combined = this.chunks.join("");
+        const cleaned = stripAnsi(combined);
+        if (detectPromptEnd(cleaned) && this.chunks.length > 1) {
+          this.finish();
+        }
+      }, 200);
+    });
+  }
+
+  push(data: string): void {
+    this.chunks.push(data);
+  }
+
+  private finish(): void {
+    if (this.timeoutId) clearTimeout(this.timeoutId);
+    if (this.promptCheckId) clearInterval(this.promptCheckId);
+
+    const combined = this.chunks.join("");
+    const cleaned = stripAnsi(combined);
+    this.resolve?.(cleaned);
+    this.resolve = undefined;
+  }
+
+  dispose(): void {
+    if (this.timeoutId) clearTimeout(this.timeoutId);
+    if (this.promptCheckId) clearInterval(this.promptCheckId);
+    this.resolve?.("");
+  }
+}

--- a/apps/desktop/src/main/services/ai/plan-guard.ts
+++ b/apps/desktop/src/main/services/ai/plan-guard.ts
@@ -1,0 +1,70 @@
+import type { AiExecutionPlan, AiExecutionStep } from "../../../../../../packages/core/src/index";
+
+const RISKY_COMMAND_PATTERNS: RegExp[] = [
+  /\brm\b/i,
+  /(^|[\s"'`])\/etc\//i,
+  /\b(?:systemctl|service)\s+restart\b/i,
+  /\breboot\b/i,
+  /\b(?:chmod|chown)\b/i,
+  /\b(?:apt|apt-get|yum|dnf|apk|pacman|brew)\s+(?:install|remove|upgrade|update)\b/i,
+  /\b(?:fdisk|mkfs|mount|umount|parted)\b/i,
+  /\b(?:iptables|firewall-cmd|ufw)\b/i,
+];
+
+const FORBIDDEN_COMMAND_PATTERNS: Array<{ pattern: RegExp; message: string }> = [
+  {
+    pattern: /(^|[;&|]\s*)(?:sudo\s+)?rm\s+-[^\n]*r[^\n]*f[^\n]*\s+(?:--no-preserve-root\s+)?\/(?=\s|$|[;&|])/i,
+    message: "禁止执行会删除根目录的 rm -rf / 命令",
+  },
+  {
+    pattern: /\b(?:systemctl|service)\s+(?:stop|disable|mask)\s+ssh(?:d)?\b/i,
+    message: "禁止执行可能导致远程 SSH 断联的命令",
+  },
+];
+
+const normalizeStepDescription = (description: string, index: number): string => {
+  const trimmed = description.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  return `执行步骤 ${index + 1}`;
+};
+
+export const isRiskyAiCommand = (command: string): boolean => {
+  return RISKY_COMMAND_PATTERNS.some((pattern) => pattern.test(command));
+};
+
+export const assertAiCommandAllowed = (command: string): void => {
+  for (const rule of FORBIDDEN_COMMAND_PATTERNS) {
+    if (rule.pattern.test(command)) {
+      throw new Error(rule.message);
+    }
+  }
+};
+
+export const normalizeApprovedPlan = (plan: AiExecutionPlan): AiExecutionPlan => {
+  const normalizedSteps: AiExecutionStep[] = plan.steps.map((step, index) => {
+    const command = step.command.trim();
+    if (!command) {
+      throw new Error(`步骤 ${index + 1} 的命令不能为空`);
+    }
+
+    assertAiCommandAllowed(command);
+
+    return {
+      step: index + 1,
+      command,
+      description: normalizeStepDescription(step.description, index),
+      risky: isRiskyAiCommand(command),
+    };
+  });
+
+  if (normalizedSteps.length === 0) {
+    throw new Error("执行计划至少需要一个有效步骤");
+  }
+
+  return {
+    summary: plan.summary.trim(),
+    steps: normalizedSteps,
+  };
+};

--- a/apps/desktop/src/main/services/ai/plan-parser.ts
+++ b/apps/desktop/src/main/services/ai/plan-parser.ts
@@ -1,0 +1,37 @@
+import type { AiExecutionPlan } from "../../../../../../packages/core/src/index";
+
+/**
+ * 从 LLM 回复文本中提取 JSON 执行计划。
+ * 支持 ```json ... ``` 代码块格式。
+ */
+export const extractPlanFromResponse = (content: string): AiExecutionPlan | undefined => {
+  const jsonBlockRegex = /```json\s*\n([\s\S]*?)\n\s*```/;
+  const match = jsonBlockRegex.exec(content);
+  if (!match?.[1]) return undefined;
+
+  try {
+    const parsed = JSON.parse(match[1]) as {
+      plan?: Array<{
+        step: number;
+        command: string;
+        description: string;
+        risky?: boolean;
+      }>;
+      summary?: string;
+    };
+
+    if (!Array.isArray(parsed.plan) || parsed.plan.length === 0) return undefined;
+
+    return {
+      steps: parsed.plan.map((s, i) => ({
+        step: s.step ?? i + 1,
+        command: String(s.command ?? ""),
+        description: String(s.description ?? ""),
+        risky: Boolean(s.risky),
+      })),
+      summary: String(parsed.summary ?? ""),
+    };
+  } catch {
+    return undefined;
+  }
+};

--- a/apps/desktop/src/main/services/ai/prompt-templates.ts
+++ b/apps/desktop/src/main/services/ai/prompt-templates.ts
@@ -1,0 +1,83 @@
+export const SYSTEM_PROMPT = `你是 NextShell AI 运维助手，一个专业的 Linux/Unix 服务器运维专家。你通过 SSH 连接帮助用户管理远程服务器。
+
+## 核心能力
+- 理解用户的自然语言运维需求
+- 将需求转化为可执行的 shell 命令序列
+- 分析命令执行结果并做出判断
+- 遇到错误时提供修复方案
+
+## 输出规则
+
+### 当用户描述一个需要执行命令的运维需求时
+你必须在回复中包含一个 JSON 格式的执行计划，用 \`\`\`json 代码块包裹：
+
+\`\`\`json
+{
+  "plan": [
+    { "step": 1, "command": "命令内容", "description": "这条命令的作用", "risky": false },
+    { "step": 2, "command": "命令内容", "description": "这条命令的作用", "risky": true }
+  ],
+  "summary": "整体计划说明"
+}
+\`\`\`
+
+### risky 标记规则
+以下操作必须标记为 risky: true：
+- 任何 rm 命令（尤其是 rm -rf）
+- 修改系统配置文件（/etc/ 下的文件）
+- 重启服务或系统（systemctl restart, reboot）
+- 修改权限（chmod, chown）
+- 包管理操作（apt install, yum install）
+- 磁盘操作（fdisk, mkfs, mount）
+- 网络配置变更（iptables, firewall-cmd）
+
+### 当用户只是咨询或闲聊时
+正常回复，不需要生成执行计划。
+
+## 分析执行结果时
+当收到命令执行结果后：
+1. 分析输出是否表明命令执行成功
+2. 如果有错误，说明原因并建议修复方案
+3. 如果需要执行后续步骤（包括进一步排查、优化、修复等任何需要在服务器上运行命令的建议），**必须**生成新的 JSON 执行计划，不要只用文字描述建议的命令
+4. 如果所有目标已完成且无需后续操作，明确告知用户
+
+**关键规则**：任何涉及"建议执行"、"可以运行"、"推荐检查"等后续操作的建议，都必须以 JSON 执行计划格式输出，让用户可以审批后再执行。禁止只用文字列出建议命令而不生成执行计划。
+
+## 安全约束
+- 绝对禁止执行 \`rm -rf /\` 或类似危险的全盘删除命令
+- 不要执行可能导致系统无法远程访问的命令（如关闭 SSH 服务）
+- 涉及敏感操作时必须在 description 中明确警告
+- 密码和密钥等敏感信息不要出现在命令中`;
+
+export interface AnalysisPromptOptions {
+  command: string;
+  output: string;
+  exitCode: number | null;
+  wasTruncated: boolean;
+  totalLines: number;
+  totalChars: number;
+}
+
+export const buildAnalysisPrompt = (opts: AnalysisPromptOptions): string => {
+  const { command, output, exitCode, wasTruncated, totalLines, totalChars } = opts;
+
+  const truncateNotice = wasTruncated
+    ? `\n⚠️ 输出过长（共 ${totalLines} 行 / ${totalChars} 字符），已截取头部和尾部关键内容。如需查看完整输出中的特定部分，请生成执行计划使用管道命令（如 grep、head、tail、awk）提取。\n`
+    : "";
+
+  return `刚才执行了命令：\`${command}\`
+
+退出码：${exitCode ?? "未知"}
+${truncateNotice}
+输出：
+\`\`\`
+${output}
+\`\`\`
+
+请分析这个执行结果：
+1. 命令是否执行成功？
+2. 输出的关键信息是什么？
+3. 是否需要执行后续操作？
+
+**重要**：如果你建议执行任何后续命令（包括进一步排查、优化、修复等），必须以 JSON 执行计划的格式输出（用 \`\`\`json 代码块包裹），让用户可以审批后再执行。不要只用文字描述建议的命令，所有可执行的建议都必须放入执行计划中。`;
+};

--- a/apps/desktop/src/main/services/command-service.ts
+++ b/apps/desktop/src/main/services/command-service.ts
@@ -35,6 +35,19 @@ interface CommandServiceOptions {
   }) => void;
 }
 
+export class CommandExecTimeoutError extends Error {
+  constructor(message = "远端命令执行超时") {
+    super(message);
+    this.name = "CommandExecTimeoutError";
+  }
+}
+
+export interface CommandExecOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  skipAudit?: boolean;
+}
+
 export class CommandService {
   private readonly connections: CachedConnectionRepository;
   private readonly getConnectionOrThrow: (id: string) => ConnectionProfile;
@@ -51,10 +64,50 @@ export class CommandService {
   async execCommand(
     connectionId: string,
     command: string,
+    options?: CommandExecOptions,
   ): Promise<CommandExecutionResult> {
     this.getConnectionOrThrow(connectionId);
     const connection = await this.ensureConnection(connectionId);
-    const result = await connection.exec(command);
+    const controller = new AbortController();
+    const timeoutMs = options?.timeoutMs;
+    const externalSignal = options?.signal;
+
+    if (externalSignal?.aborted) {
+      throw externalSignal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+    }
+
+    const forwardAbort = () => {
+      controller.abort(
+        externalSignal?.reason ?? new DOMException("The operation was aborted.", "AbortError")
+      );
+    };
+    externalSignal?.addEventListener("abort", forwardAbort, { once: true });
+
+    const timeoutId = Number.isFinite(timeoutMs) && (timeoutMs ?? 0) > 0
+      ? setTimeout(() => {
+          controller.abort(new CommandExecTimeoutError());
+        }, timeoutMs)
+      : undefined;
+
+    let result;
+    try {
+      result = await connection.exec(command, { signal: controller.signal });
+    } catch (error) {
+      const reason = controller.signal.reason;
+      if (reason instanceof CommandExecTimeoutError) {
+        throw reason;
+      }
+      if (externalSignal?.aborted && externalSignal.reason) {
+        throw externalSignal.reason;
+      }
+      throw error;
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      externalSignal?.removeEventListener("abort", forwardAbort);
+    }
+
     const execution: CommandExecutionResult = {
       connectionId,
       command,
@@ -63,13 +116,15 @@ export class CommandService {
       exitCode: result.exitCode,
       executedAt: new Date().toISOString(),
     };
-    this.appendAuditLogIfEnabled({
-      action: "command.exec",
-      level: result.exitCode === 0 ? "info" : "warn",
-      connectionId,
-      message: "Executed command on remote host",
-      metadata: { command, exitCode: result.exitCode },
-    });
+    if (!options?.skipAudit) {
+      this.appendAuditLogIfEnabled({
+        action: "command.exec",
+        level: result.exitCode === 0 ? "info" : "warn",
+        connectionId,
+        message: "Executed command on remote host",
+        metadata: { command, exitCode: result.exitCode },
+      });
+    }
     return execution;
   }
 

--- a/apps/desktop/src/main/services/container-types.ts
+++ b/apps/desktop/src/main/services/container-types.ts
@@ -1,5 +1,6 @@
 import type { WebContents } from "electron";
 import type {
+  AiConversation,
   AppPreferences,
   BackupArchiveMeta,
   BackupConflictPolicy,
@@ -73,6 +74,12 @@ import type {
   ResourceCopySshKeyInput,
   RecycleBinRestoreInput,
   RecycleBinPurgeInput,
+  AiChatInput,
+  AiApproveInput,
+  AiAbortInput,
+  AiHistoryInput,
+  AiProviderTestInput,
+  AiProviderSetApiKeyInput,
 } from "../../../../../packages/shared/src/index";
 import type { SystemMonitorController } from "./monitor/system-monitor-controller";
 import type { ProcessMonitorController } from "./monitor/process-monitor-controller";
@@ -312,6 +319,14 @@ export interface ServiceContainer {
   recycleBinRestore: (input: RecycleBinRestoreInput) => Promise<ConnectionProfile | SshKeyProfile>;
   recycleBinPurge: (input: RecycleBinPurgeInput) => void;
   recycleBinClear: () => void;
+
+  // AI Assistant
+  aiChat: (sender: WebContents, input: AiChatInput) => Promise<{ conversationId: string }>;
+  aiApprove: (sender: WebContents, input: AiApproveInput) => Promise<{ ok: true }>;
+  aiAbort: (sender: WebContents, input: AiAbortInput) => { ok: true };
+  aiHistory: (sender: WebContents, input: AiHistoryInput) => AiConversation[];
+  aiTestProvider: (input: AiProviderTestInput) => Promise<{ ok: boolean; error?: string }>;
+  aiSetApiKey: (input: AiProviderSetApiKeyInput) => Promise<void>;
 
   dispose: () => Promise<void>;
 }

--- a/apps/desktop/src/main/services/container.ts
+++ b/apps/desktop/src/main/services/container.ts
@@ -61,6 +61,7 @@ import { ResourceOperationsService } from "./resource-operations-service";
 import { MonitorService } from "./monitor-service";
 import { SftpService } from "./sftp-service";
 import { SessionService } from "./session-service";
+import { AiService } from "./ai/ai-service";
 
 // Re-export for consumers (index.ts, register.ts)
 export type { ServiceContainer, CreateServiceContainerOptions } from "./container-types";
@@ -466,6 +467,16 @@ export const createServiceContainer = (
   });
   cloudSyncManager.initialize();
 
+  // AI Service
+  const aiSvc = new AiService({
+    execCommand: (connectionId, cmd, execOptions) => commandSvc.execCommand(connectionId, cmd, execOptions),
+    execInSession: (sessionId, cmd, execOptions) => sessionSvc.execCommandInSession(sessionId, cmd, execOptions),
+    vault,
+    getPreferences: () => connections.getAppPreferences(),
+    dataDir: options.dataDir,
+    appendAuditLog: (payload) => appendAuditLogIfEnabled(payload),
+  });
+
   // Resource Operations Service
   const resourceOpsSvc = new ResourceOperationsService({
     connections,
@@ -483,6 +494,7 @@ export const createServiceContainer = (
     connections.flush();
     if (auditPurgeTimer) clearInterval(auditPurgeTimer);
     prefsSvc.dispose();
+    aiSvc.dispose();
 
     const allMonitorIds = monitorSvc.getAllConnectionIds();
     await Promise.all(allMonitorIds.map((id) => monitorSvc.disposeAllMonitorSessions(id)));
@@ -641,6 +653,14 @@ export const createServiceContainer = (
     recycleBinRestore: (i) => resourceOpsSvc.restoreFromRecycleBin(i),
     recycleBinPurge: (i) => { resourceOpsSvc.purgeRecycleBinEntry(i.id); },
     recycleBinClear: () => { connections.clearRecycleBin(); },
+
+    // AI Assistant
+    aiChat: (sender, i) => aiSvc.chat(sender, i),
+    aiApprove: (sender, i) => aiSvc.approve(sender, i),
+    aiAbort: (sender, i) => aiSvc.abort(sender, i),
+    aiHistory: (sender, i) => aiSvc.history(sender, i),
+    aiTestProvider: (i) => aiSvc.testProvider(i),
+    aiSetApiKey: (i) => aiSvc.setApiKey(i.providerId, i.apiKey),
 
     dispose,
   };

--- a/apps/desktop/src/main/services/preferences.ts
+++ b/apps/desktop/src/main/services/preferences.ts
@@ -251,6 +251,39 @@ export const mergePreferences = (
         patch.audit.retentionDays <= 365
           ? patch.audit.retentionDays
           : current.audit.retentionDays
+    },
+    ai: {
+      enabled: patch.ai?.enabled ?? current.ai.enabled,
+      activeProviderId:
+        patch.ai?.activeProviderId !== undefined
+          ? patch.ai.activeProviderId
+          : current.ai.activeProviderId,
+      providers: patch.ai?.providers ?? current.ai.providers,
+      systemPromptOverride:
+        patch.ai?.systemPromptOverride !== undefined
+          ? patch.ai.systemPromptOverride
+          : current.ai.systemPromptOverride,
+      executionTimeoutSec:
+        patch.ai?.executionTimeoutSec !== undefined &&
+        Number.isInteger(patch.ai.executionTimeoutSec) &&
+        patch.ai.executionTimeoutSec >= 5 &&
+        patch.ai.executionTimeoutSec <= 300
+          ? patch.ai.executionTimeoutSec
+          : current.ai.executionTimeoutSec,
+      providerRequestTimeoutSec:
+        patch.ai?.providerRequestTimeoutSec !== undefined &&
+        Number.isInteger(patch.ai.providerRequestTimeoutSec) &&
+        patch.ai.providerRequestTimeoutSec >= 5 &&
+        patch.ai.providerRequestTimeoutSec <= 120
+          ? patch.ai.providerRequestTimeoutSec
+          : current.ai.providerRequestTimeoutSec,
+      providerMaxRetries:
+        patch.ai?.providerMaxRetries !== undefined &&
+        Number.isInteger(patch.ai.providerMaxRetries) &&
+        patch.ai.providerMaxRetries >= 0 &&
+        patch.ai.providerMaxRetries <= 3
+          ? patch.ai.providerMaxRetries
+          : current.ai.providerMaxRetries
     }
   };
 };

--- a/apps/desktop/src/main/services/session-service.ts
+++ b/apps/desktop/src/main/services/session-service.ts
@@ -4,6 +4,7 @@ import type { WebContents } from "electron";
 import { spawn as spawnPty } from "node-pty";
 import type {
   ConnectionProfile,
+  CommandExecutionResult,
   SessionDescriptor,
   SessionStatus,
 } from "@nextshell/core";
@@ -46,6 +47,20 @@ export interface SessionServiceOptions {
   persistAuthOverride: (connectionId: string, authOverride: SessionAuthOverrideInput) => Promise<string | undefined>;
 }
 
+interface SessionExecOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+interface SessionVisibleFilter {
+  wrappedCommand: string | null;
+  startSentinel: string;
+  endPrefix: string;
+  endSuffix: string;
+  buffer: string;
+  suppressNextNewline: boolean;
+}
+
 export class SessionService {
   private readonly connections: CachedConnectionRepository;
   private readonly activeSessions: Map<string, ActiveSession>;
@@ -61,6 +76,10 @@ export class SessionService {
   private readonly ensureSystemMonitorRuntime: (connectionId: string) => Promise<SystemMonitorRuntime>;
   private readonly warmupSftp: (connectionId: string, connection: SshConnection) => Promise<string | undefined>;
   private readonly persistAuthOverride: (connectionId: string, authOverride: SessionAuthOverrideInput) => Promise<string | undefined>;
+  private readonly sessionOutputListeners = new Map<string, Set<(chunk: string) => void>>();
+  private readonly sessionCloseListeners = new Map<string, Set<(reason?: string) => void>>();
+  private readonly sessionVisibleFilters = new Map<string, SessionVisibleFilter>();
+  private readonly sessionExecLocks = new Set<string>();
 
   constructor(options: SessionServiceOptions) {
     this.connections = options.connections;
@@ -176,11 +195,17 @@ export class SessionService {
         if (!active) {
           return;
         }
+        const decodedChunk = decodeTerminalData(chunk, active.terminalEncoding);
+        this.emitSessionOutput(descriptor.id, decodedChunk);
+        const visibleChunk = this.transformVisibleSessionOutput(descriptor.id, decodedChunk);
+        if (!visibleChunk) {
+          return;
+        }
 
         this.sessionDataDispatcher.push({
           streamId: descriptor.id,
           sender: active.sender,
-          chunk: decodeTerminalData(chunk, active.terminalEncoding),
+          chunk: visibleChunk,
           onPause: () => shell.pause(),
           onResume: () => shell.resume(),
         });
@@ -191,10 +216,16 @@ export class SessionService {
         if (!active) {
           return;
         }
+        const decodedChunk = decodeTerminalData(chunk, active.terminalEncoding);
+        this.emitSessionOutput(descriptor.id, decodedChunk);
+        const visibleChunk = this.transformVisibleSessionOutput(descriptor.id, decodedChunk);
+        if (!visibleChunk) {
+          return;
+        }
         this.sessionDataDispatcher.push({
           streamId: descriptor.id,
           sender: active.sender,
-          chunk: decodeTerminalData(chunk, active.terminalEncoding),
+          chunk: visibleChunk,
           onPause: () => shell.pause(),
           onResume: () => shell.resume(),
         });
@@ -335,11 +366,16 @@ export class SessionService {
         if (!active || active.kind !== "local") {
           return;
         }
+        this.emitSessionOutput(descriptor.id, chunk);
+        const visibleChunk = this.transformVisibleSessionOutput(descriptor.id, chunk);
+        if (!visibleChunk) {
+          return;
+        }
 
         this.sessionDataDispatcher.push({
           streamId: descriptor.id,
           sender: active.sender,
-          chunk,
+          chunk: visibleChunk,
           onPause: () => pty.pause(),
           onResume: () => pty.resume(),
         });
@@ -416,6 +452,144 @@ export class SessionService {
     return { ok: true };
   }
 
+  async execCommandInSession(
+    sessionId: string,
+    command: string,
+    options?: SessionExecOptions,
+  ): Promise<CommandExecutionResult> {
+    const active = this.activeSessions.get(sessionId);
+    if (!active) {
+      throw new Error("Session not found");
+    }
+    if (active.kind !== "remote") {
+      throw new Error("AI 仅支持在远端终端会话中执行命令");
+    }
+    if (this.sessionExecLocks.has(sessionId)) {
+      throw new Error("当前终端正在执行其他 AI 命令，请稍后再试");
+    }
+
+    this.sessionExecLocks.add(sessionId);
+
+    const markerId = randomUUID().replace(/-/g, "");
+    const startSentinel = this.buildSessionExecSentinel(`NEXTSHELL_AI_START_${markerId}`);
+    const endPrefix = this.buildSessionExecSentinel(`NEXTSHELL_AI_END_${markerId}:`);
+    const endSuffix = "\u001b\\";
+    const wrappedCommand = [
+      `printf '%b' '${this.encodeShellBytes(startSentinel)}'`,
+      `eval -- ${this.escapeShellArg(command)}`,
+      "__ns_ai_exit=$?",
+      `printf '%b%s%b' '${this.encodeShellBytes(endPrefix)}' "$__ns_ai_exit" '${this.encodeShellBytes(endSuffix)}'`,
+    ].join("; ");
+    const chunks: string[] = [];
+
+    return await new Promise<CommandExecutionResult>((resolve, reject) => {
+      let settled = false;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+      const cleanup = (): void => {
+        if (timeoutId) clearTimeout(timeoutId);
+        this.removeSessionOutputListener(sessionId, onChunk);
+        this.removeSessionCloseListener(sessionId, onSessionClose);
+        options?.signal?.removeEventListener("abort", onAbort);
+        this.flushSessionVisibleFilter(sessionId);
+        this.sessionVisibleFilters.delete(sessionId);
+        this.sessionExecLocks.delete(sessionId);
+      };
+
+      const finalize = (
+        callback: () => void
+      ): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        callback();
+      };
+
+      const extractCommandResult = (): CommandExecutionResult | undefined => {
+        const rawOutput = chunks.join("");
+        const startIndex = rawOutput.indexOf(startSentinel);
+        if (startIndex < 0) {
+          return undefined;
+        }
+        const payloadStart = startIndex + startSentinel.length;
+        const endIndex = rawOutput.indexOf(endPrefix, payloadStart);
+        if (endIndex < 0) {
+          return undefined;
+        }
+        const exitStart = endIndex + endPrefix.length;
+        const exitEnd = rawOutput.indexOf(endSuffix, exitStart);
+        if (exitEnd < 0) {
+          return undefined;
+        }
+
+        const payload = rawOutput.slice(payloadStart, endIndex);
+        const exitCodeRaw = rawOutput.slice(exitStart, exitEnd).trim();
+        const parsedExitCode = Number.parseInt(exitCodeRaw, 10);
+        const normalizedOutput = payload
+          .replace(/^\r?\n/, "")
+          .replace(/\r?\n$/, "");
+
+        return {
+          connectionId: active.connectionId,
+          command,
+          stdout: normalizedOutput,
+          stderr: "",
+          exitCode: Number.isFinite(parsedExitCode) ? parsedExitCode : 1,
+          executedAt: new Date().toISOString(),
+        };
+      };
+
+      const onChunk = (chunk: string): void => {
+        chunks.push(chunk);
+        const result = extractCommandResult();
+        if (result) {
+          finalize(() => resolve(result));
+        }
+      };
+
+      const onAbort = (): void => {
+        this.interruptSession(sessionId);
+        finalize(() => reject(options?.signal?.reason ?? new DOMException("Aborted", "AbortError")));
+      };
+
+      const onSessionClose = (reason?: string): void => {
+        finalize(() => reject(new Error(reason ?? "终端会话已关闭，无法继续执行 AI 命令")));
+      };
+
+      this.addSessionOutputListener(sessionId, onChunk);
+      this.addSessionCloseListener(sessionId, onSessionClose);
+      this.sessionVisibleFilters.set(sessionId, {
+        wrappedCommand,
+        startSentinel,
+        endPrefix,
+        endSuffix,
+        buffer: "",
+        suppressNextNewline: false,
+      });
+      this.emitVisibleSessionCommand(sessionId, command);
+
+      if (options?.signal?.aborted) {
+        onAbort();
+        return;
+      }
+
+      options?.signal?.addEventListener("abort", onAbort, { once: true });
+
+      if (Number.isFinite(options?.timeoutMs) && (options?.timeoutMs ?? 0) > 0) {
+        timeoutId = setTimeout(() => {
+          this.interruptSession(sessionId);
+          finalize(() => reject(new Error("远端命令执行超时")));
+        }, options?.timeoutMs);
+      }
+
+      try {
+        this.writeSession(sessionId, `${wrappedCommand}\r`);
+      } catch (error) {
+        finalize(() => reject(error));
+      }
+    });
+  }
+
   resizeSession(
     sessionId: string,
     cols: number,
@@ -450,7 +624,12 @@ export class SessionService {
     this.sessionDataDispatcher.clear(sessionId);
     if (active.kind === "local") {
       active.pty.kill();
+      this.emitSessionClosed(sessionId, "终端会话已关闭");
       this.activeSessions.delete(sessionId);
+      this.sessionExecLocks.delete(sessionId);
+      this.sessionCloseListeners.delete(sessionId);
+      this.sessionVisibleFilters.delete(sessionId);
+      this.sessionOutputListeners.delete(sessionId);
       this.sendSessionStatus(active.sender, {
         sessionId,
         status: "disconnected",
@@ -470,7 +649,12 @@ export class SessionService {
       active.channel.stderr.removeAllListeners();
     }
     active.channel.end();
+    this.emitSessionClosed(sessionId, "终端会话已关闭");
     this.activeSessions.delete(sessionId);
+    this.sessionExecLocks.delete(sessionId);
+    this.sessionCloseListeners.delete(sessionId);
+    this.sessionVisibleFilters.delete(sessionId);
+    this.sessionOutputListeners.delete(sessionId);
     this.sendSessionStatus(active.sender, {
       sessionId,
       status: "disconnected",
@@ -533,6 +717,7 @@ export class SessionService {
     }
 
     active.descriptor.status = status;
+    this.emitSessionClosed(sessionId, reason);
     this.sessionDataDispatcher.closeWhenDrained(sessionId, () => {
       const drained = this.activeSessions.get(sessionId);
       if (!drained || drained.kind !== "remote") {
@@ -540,6 +725,10 @@ export class SessionService {
       }
 
       this.activeSessions.delete(sessionId);
+      this.sessionExecLocks.delete(sessionId);
+      this.sessionCloseListeners.delete(sessionId);
+      this.sessionVisibleFilters.delete(sessionId);
+      this.sessionOutputListeners.delete(sessionId);
       drained.descriptor.status = status;
       this.sendSessionStatus(drained.sender, { sessionId, status, reason });
       void this.closeConnectionIfIdle(drained.connectionId);
@@ -557,6 +746,7 @@ export class SessionService {
     }
 
     active.descriptor.status = status;
+    this.emitSessionClosed(sessionId, reason);
     this.sessionDataDispatcher.closeWhenDrained(sessionId, () => {
       const drained = this.activeSessions.get(sessionId);
       if (!drained || drained.kind !== "local") {
@@ -564,6 +754,10 @@ export class SessionService {
       }
 
       this.activeSessions.delete(sessionId);
+      this.sessionExecLocks.delete(sessionId);
+      this.sessionCloseListeners.delete(sessionId);
+      this.sessionVisibleFilters.delete(sessionId);
+      this.sessionOutputListeners.delete(sessionId);
       drained.descriptor.status = status;
       this.sendSessionStatus(drained.sender, { sessionId, status, reason });
       this.appendAuditLogIfEnabled({
@@ -573,5 +767,182 @@ export class SessionService {
         metadata: { sessionId, reason },
       });
     });
+  }
+
+  private addSessionOutputListener(sessionId: string, listener: (chunk: string) => void): void {
+    const listeners = this.sessionOutputListeners.get(sessionId) ?? new Set<(chunk: string) => void>();
+    listeners.add(listener);
+    this.sessionOutputListeners.set(sessionId, listeners);
+  }
+
+  private removeSessionOutputListener(sessionId: string, listener: (chunk: string) => void): void {
+    const listeners = this.sessionOutputListeners.get(sessionId);
+    if (!listeners) return;
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      this.sessionOutputListeners.delete(sessionId);
+    }
+  }
+
+  private emitSessionOutput(sessionId: string, chunk: string): void {
+    const listeners = this.sessionOutputListeners.get(sessionId);
+    if (!listeners || listeners.size === 0) return;
+    for (const listener of listeners) {
+      listener(chunk);
+    }
+  }
+
+  private addSessionCloseListener(sessionId: string, listener: (reason?: string) => void): void {
+    const listeners = this.sessionCloseListeners.get(sessionId) ?? new Set<(reason?: string) => void>();
+    listeners.add(listener);
+    this.sessionCloseListeners.set(sessionId, listeners);
+  }
+
+  private removeSessionCloseListener(sessionId: string, listener: (reason?: string) => void): void {
+    const listeners = this.sessionCloseListeners.get(sessionId);
+    if (!listeners) return;
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      this.sessionCloseListeners.delete(sessionId);
+    }
+  }
+
+  private emitSessionClosed(sessionId: string, reason?: string): void {
+    const listeners = this.sessionCloseListeners.get(sessionId);
+    if (!listeners || listeners.size === 0) return;
+    for (const listener of listeners) {
+      listener(reason);
+    }
+  }
+
+  private emitVisibleSessionCommand(sessionId: string, command: string): void {
+    this.pushSessionVisibleChunk(sessionId, `${command}\r\n`);
+  }
+
+  private flushSessionVisibleFilter(sessionId: string): void {
+    const filter = this.sessionVisibleFilters.get(sessionId);
+    if (!filter) {
+      return;
+    }
+    const visibleChunk = this.transformVisibleSessionOutput(sessionId, "", { flushAll: true });
+    if (visibleChunk) {
+      this.pushSessionVisibleChunk(sessionId, visibleChunk);
+    }
+  }
+
+  private pushSessionVisibleChunk(sessionId: string, chunk: string): void {
+    if (!chunk) {
+      return;
+    }
+    const active = this.activeSessions.get(sessionId);
+    if (!active) {
+      return;
+    }
+    this.sessionDataDispatcher.push({
+      streamId: sessionId,
+      sender: active.sender,
+      chunk,
+      onPause: () => undefined,
+      onResume: () => undefined,
+    });
+  }
+
+  private transformVisibleSessionOutput(
+    sessionId: string,
+    chunk: string,
+    options?: { flushAll?: boolean },
+  ): string {
+    const filter = this.sessionVisibleFilters.get(sessionId);
+    if (!filter) {
+      return chunk;
+    }
+
+    filter.buffer += chunk;
+    let output = filter.buffer;
+
+    if (filter.wrappedCommand) {
+      const wrappedIndex = output.indexOf(filter.wrappedCommand);
+      if (wrappedIndex >= 0) {
+        output = output.slice(0, wrappedIndex) + output.slice(wrappedIndex + filter.wrappedCommand.length);
+        filter.wrappedCommand = null;
+        filter.suppressNextNewline = true;
+      }
+    }
+
+    if (filter.suppressNextNewline) {
+      if (output.startsWith("\r\n")) {
+        output = output.slice(2);
+        filter.suppressNextNewline = false;
+      } else if (output.startsWith("\n") || output.startsWith("\r")) {
+        output = output.slice(1);
+        filter.suppressNextNewline = false;
+      }
+    }
+
+    output = output.split(filter.startSentinel).join("");
+
+    while (true) {
+      const startIndex = output.indexOf(filter.endPrefix);
+      if (startIndex < 0) {
+        break;
+      }
+      const endIndex = output.indexOf(filter.endSuffix, startIndex + filter.endPrefix.length);
+      if (endIndex < 0) {
+        break;
+      }
+      output = output.slice(0, startIndex) + output.slice(endIndex + filter.endSuffix.length);
+    }
+
+    if (options?.flushAll) {
+      if (filter.wrappedCommand) {
+        output = "";
+        filter.wrappedCommand = null;
+      }
+      if (filter.suppressNextNewline) {
+        output = output.replace(/^(?:\r\n|\n|\r)/, "");
+        filter.suppressNextNewline = false;
+      }
+      filter.buffer = "";
+      return output;
+    }
+
+    const tailLength = this.getSessionVisibleFilterTailLength(filter);
+    if (output.length <= tailLength) {
+      filter.buffer = output;
+      return "";
+    }
+
+    const visibleChunk = output.slice(0, output.length - tailLength);
+    filter.buffer = output.slice(output.length - tailLength);
+    return visibleChunk;
+  }
+
+  private getSessionVisibleFilterTailLength(filter: SessionVisibleFilter): number {
+    const echoTail = filter.wrappedCommand ? filter.wrappedCommand.length : 0;
+    const startTail = filter.startSentinel.length;
+    const endTail = filter.endPrefix.length + filter.endSuffix.length + 8;
+    return Math.max(echoTail, startTail, endTail);
+  }
+
+  private buildSessionExecSentinel(marker: string): string {
+    return `\u001bP${marker}\u001b\\`;
+  }
+
+  private encodeShellBytes(value: string): string {
+    return Array.from(value)
+      .map((char) => `\\${char.charCodeAt(0).toString(8).padStart(3, "0")}`)
+      .join("");
+  }
+
+  private interruptSession(sessionId: string): void {
+    try {
+      this.writeSession(sessionId, "\u0003");
+    } catch {
+      // 会话已关闭时无需重复抛错，后续由关闭回调收敛 Promise。
+    }
+  }
+
+  private escapeShellArg(arg: string): string {
+    return `'${arg.replace(/'/g, "'\\''")}'`;
   }
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 import type {
+  AiStreamEvent,
+  AiProgressEvent,
   CloudSyncManagerStatusEvent,
   DebugLogEntry,
   SessionDataEvent,
@@ -314,6 +316,28 @@ const api: NextShellApi = {
     restore: (payload) => ipcRenderer.invoke(IPCChannel.RecycleBinRestore, payload),
     purge: (payload) => ipcRenderer.invoke(IPCChannel.RecycleBinPurge, payload),
     clear: () => ipcRenderer.invoke(IPCChannel.RecycleBinClear, {})
+  },
+  ai: {
+    chat: (payload) => ipcRenderer.invoke(IPCChannel.AiChat, payload),
+    approve: (payload) => ipcRenderer.invoke(IPCChannel.AiApprove, payload),
+    abort: (payload) => ipcRenderer.invoke(IPCChannel.AiAbort, payload),
+    history: (payload) => ipcRenderer.invoke(IPCChannel.AiHistory, payload ?? {}),
+    testProvider: (payload) => ipcRenderer.invoke(IPCChannel.AiProviderTest, payload),
+    setApiKey: (payload) => ipcRenderer.invoke(IPCChannel.AiProviderSetApiKey, payload),
+    onStream: (listener) => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: AiStreamEvent) => {
+        listener(payload);
+      };
+      ipcRenderer.on(IPCChannel.AiStreamEvent, handler);
+      return () => { ipcRenderer.off(IPCChannel.AiStreamEvent, handler); };
+    },
+    onProgress: (listener) => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: AiProgressEvent) => {
+        listener(payload);
+      };
+      ipcRenderer.on(IPCChannel.AiProgressEvent, handler);
+      return () => { ipcRenderer.off(IPCChannel.AiProgressEvent, handler); };
+    }
   },
   platform: process.platform,
   ui: {

--- a/apps/desktop/src/renderer/components/SettingsCenterModal.tsx
+++ b/apps/desktop/src/renderer/components/SettingsCenterModal.tsx
@@ -17,6 +17,7 @@ import {
   NetworkSection,
   BackupSection,
   SecuritySection,
+  AiSection,
   AboutSection,
 } from "./settings-center";
 
@@ -466,6 +467,19 @@ export const SettingsCenterModal = ({ open, onClose }: SettingsCenterModalProps)
           onRunBackup={() => void handleRunBackup()}
           onListArchives={() => void handleListArchives()}
           onRestore={(id) => void handleRestore(id)}
+          save={save}
+          message={message}
+        />;
+
+      case "ai":
+        return <AiSection
+          loading={loading}
+          enabled={preferences.ai.enabled}
+          providers={preferences.ai.providers}
+          activeProviderId={preferences.ai.activeProviderId}
+          executionTimeoutSec={preferences.ai.executionTimeoutSec}
+          providerRequestTimeoutSec={preferences.ai.providerRequestTimeoutSec}
+          providerMaxRetries={preferences.ai.providerMaxRetries}
           save={save}
           message={message}
         />;

--- a/apps/desktop/src/renderer/components/settings-center/ai-section.tsx
+++ b/apps/desktop/src/renderer/components/settings-center/ai-section.tsx
@@ -1,0 +1,388 @@
+import { useState } from "react";
+import {
+  Button,
+  Input,
+  InputNumber,
+  Select,
+  Space,
+  Tag,
+  Typography
+} from "antd";
+import { type AiProviderConfig, type AiProviderType } from "@nextshell/core";
+import { SettingsCard, SettingsRow, SettingsSwitchRow } from "./shared-components";
+import type { SaveFn } from "./types";
+import { formatAiErrorMessage } from "../../utils/ai-error-message";
+
+const PROVIDER_TYPE_OPTIONS: Array<{ label: string; value: AiProviderType }> = [
+  { label: "OpenAI 兼容", value: "openai" },
+  { label: "Anthropic Claude", value: "anthropic" },
+  { label: "Google Gemini", value: "gemini" },
+];
+
+const DEFAULT_BASE_URLS: Record<AiProviderType, string> = {
+  openai: "https://api.openai.com/v1",
+  anthropic: "https://api.anthropic.com",
+  gemini: "https://generativelanguage.googleapis.com",
+};
+
+const DEFAULT_MODELS: Record<AiProviderType, string> = {
+  openai: "gpt-4o",
+  anthropic: "claude-sonnet-4-20250514",
+  gemini: "gemini-2.5-flash",
+};
+
+interface AiSectionProps {
+  loading: boolean;
+  enabled: boolean;
+  providers: AiProviderConfig[];
+  activeProviderId?: string;
+  executionTimeoutSec: number;
+  providerRequestTimeoutSec: number;
+  providerMaxRetries: number;
+  save: SaveFn;
+  message: { success: (msg: string) => void; error: (msg: string) => void; warning: (msg: string) => void };
+}
+
+export const AiSection = ({
+  loading,
+  enabled,
+  providers,
+  activeProviderId,
+  executionTimeoutSec,
+  providerRequestTimeoutSec,
+  providerMaxRetries,
+  save,
+  message,
+}: AiSectionProps) => {
+  const [editingProvider, setEditingProvider] = useState<AiProviderConfig | null>(null);
+  const [apiKeyInput, setApiKeyInput] = useState("");
+  const [testing, setTesting] = useState(false);
+
+  const startAddProvider = (): void => {
+    const defaultType: AiProviderType = "openai";
+    setEditingProvider({
+      id: crypto.randomUUID(),
+      type: defaultType,
+      name: "",
+      baseUrl: DEFAULT_BASE_URLS[defaultType],
+      model: DEFAULT_MODELS[defaultType],
+      enabled: true,
+    });
+    setApiKeyInput("");
+  };
+
+  const startEditProvider = (provider: AiProviderConfig): void => {
+    setEditingProvider({ ...provider });
+    setApiKeyInput("");
+  };
+
+  const handleProviderTypeChange = (type: AiProviderType): void => {
+    if (!editingProvider) return;
+    setEditingProvider({
+      ...editingProvider,
+      type,
+      baseUrl: DEFAULT_BASE_URLS[type],
+      model: DEFAULT_MODELS[type],
+    });
+  };
+
+  const handleSaveProvider = async (): Promise<void> => {
+    if (!editingProvider) return;
+    if (!editingProvider.name.trim()) {
+      message.warning("请输入提供商名称");
+      return;
+    }
+    if (!editingProvider.baseUrl.trim()) {
+      message.warning("请输入 API 地址");
+      return;
+    }
+    if (!editingProvider.model.trim()) {
+      message.warning("请输入模型名称");
+      return;
+    }
+
+    if (apiKeyInput.trim()) {
+      try {
+        await window.nextshell.ai.setApiKey({
+          providerId: editingProvider.id,
+          apiKey: apiKeyInput.trim(),
+        });
+        editingProvider.apiKeyRef = `secret://ai-provider-${editingProvider.id}`;
+      } catch (err) {
+        message.error(`保存 API Key 失败：${err instanceof Error ? err.message : "未知错误"}`);
+        return;
+      }
+    }
+
+    const existingIdx = providers.findIndex((p) => p.id === editingProvider.id);
+    const updated = [...providers];
+    if (existingIdx >= 0) {
+      updated[existingIdx] = editingProvider;
+    } else {
+      updated.push(editingProvider);
+    }
+
+    const isFirstProvider = providers.length === 0;
+    save({
+      ai: {
+        providers: updated,
+        ...(isFirstProvider ? { activeProviderId: editingProvider.id, enabled: true } : {}),
+      },
+    });
+
+    setEditingProvider(null);
+    setApiKeyInput("");
+    message.success("提供商配置已保存");
+  };
+
+  const handleRemoveProvider = (id: string): void => {
+    const updated = providers.filter((p) => p.id !== id);
+    const patch: Record<string, unknown> = { providers: updated };
+    if (activeProviderId === id) {
+      patch.activeProviderId = updated[0]?.id;
+    }
+    save({ ai: patch });
+  };
+
+  const handleTestProvider = async (): Promise<void> => {
+    if (!editingProvider) return;
+    const key = apiKeyInput.trim();
+    if (!key) {
+      message.warning("请先输入 API Key 以进行测试");
+      return;
+    }
+    setTesting(true);
+    try {
+      const result = await window.nextshell.ai.testProvider({
+        type: editingProvider.type,
+        baseUrl: editingProvider.baseUrl,
+        model: editingProvider.model,
+        apiKey: key,
+      });
+      if (result.ok) {
+        message.success("连接测试成功");
+      } else {
+        message.error(`连接测试失败：${formatAiErrorMessage(result.error, "未知错误")}`);
+      }
+    } catch (err) {
+      message.error(`测试失败：${formatAiErrorMessage(err, "未知错误")}`);
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <>
+      <SettingsCard title="AI 助手" description="配置大模型接口，使用 AI 辅助执行运维操作">
+        <SettingsSwitchRow
+          label="启用 AI 助手"
+          checked={enabled}
+          disabled={loading}
+          onChange={(v) => save({ ai: { enabled: v } })}
+        />
+
+        {enabled && (
+          <>
+            <SettingsRow label="命令执行超时（秒）" hint="AI 执行单条命令的最大等待时间">
+              <InputNumber
+                min={5}
+                max={300}
+                value={executionTimeoutSec}
+                disabled={loading}
+                onChange={(v) => {
+                  if (v !== null) save({ ai: { executionTimeoutSec: v } });
+                }}
+                style={{ width: 120 }}
+              />
+            </SettingsRow>
+
+            <SettingsRow label="模型请求超时（秒）" hint="单次调用 OpenAI / Claude / Gemini 的最大等待时间">
+              <InputNumber
+                min={5}
+                max={120}
+                value={providerRequestTimeoutSec}
+                disabled={loading}
+                onChange={(v) => {
+                  if (v !== null) save({ ai: { providerRequestTimeoutSec: v } });
+                }}
+                style={{ width: 120 }}
+              />
+            </SettingsRow>
+
+            <SettingsRow label="模型请求重试次数" hint="遇到 429 或 5xx 等可重试错误时的最大自动重试次数">
+              <InputNumber
+                min={0}
+                max={3}
+                value={providerMaxRetries}
+                disabled={loading}
+                onChange={(v) => {
+                  if (v !== null) save({ ai: { providerMaxRetries: v } });
+                }}
+                style={{ width: 120 }}
+              />
+            </SettingsRow>
+
+          </>
+        )}
+      </SettingsCard>
+
+      {enabled && (
+        <SettingsCard
+          title="模型提供商"
+          description="管理大模型 API 接口配置，支持 OpenAI 兼容（含 DeepSeek / Ollama）、Anthropic、Gemini"
+        >
+          {providers.length > 0 && (
+            <div style={{ marginBottom: 12 }}>
+              <SettingsRow label="当前使用">
+                <Select
+                  value={activeProviderId}
+                  disabled={loading}
+                  style={{ width: 200 }}
+                  onChange={(v) => save({ ai: { activeProviderId: v } })}
+                  options={providers
+                    .filter((p) => p.enabled)
+                    .map((p) => ({
+                      label: p.name,
+                      value: p.id,
+                    }))}
+                />
+              </SettingsRow>
+            </div>
+          )}
+
+          {/* Provider list */}
+          <div className="flex flex-col gap-2">
+            {providers.map((provider) => (
+              <div
+                key={provider.id}
+                className="flex items-center justify-between p-2 rounded"
+                style={{ border: "1px solid var(--border)" }}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <Tag color={provider.enabled ? "blue" : "default"}>
+                    {PROVIDER_TYPE_OPTIONS.find((o) => o.value === provider.type)?.label ?? provider.type}
+                  </Tag>
+                  <Typography.Text ellipsis style={{ maxWidth: 160 }}>
+                    {provider.name}
+                  </Typography.Text>
+                  <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                    {provider.model}
+                  </Typography.Text>
+                  {provider.id === activeProviderId && (
+                    <Tag color="green" style={{ marginLeft: 4 }}>当前</Tag>
+                  )}
+                </div>
+                <Space size={4}>
+                  <Button size="small" onClick={() => startEditProvider(provider)}>
+                    编辑
+                  </Button>
+                  <Button size="small" danger onClick={() => handleRemoveProvider(provider.id)}>
+                    删除
+                  </Button>
+                </Space>
+              </div>
+            ))}
+          </div>
+
+          {!editingProvider && (
+            <Button
+              type="dashed"
+              block
+              style={{ marginTop: 8 }}
+              onClick={startAddProvider}
+            >
+              <i className="ri-add-line" /> 添加提供商
+            </Button>
+          )}
+
+          {/* Edit / Add form */}
+          {editingProvider && (
+            <div
+              style={{
+                marginTop: 12,
+                padding: 12,
+                borderRadius: 6,
+                border: "1px solid var(--border)",
+              }}
+            >
+              <Typography.Text strong style={{ fontSize: 13 }}>
+                {providers.some((p) => p.id === editingProvider.id) ? "编辑提供商" : "添加提供商"}
+              </Typography.Text>
+
+              <SettingsRow label="类型">
+                <Select
+                  value={editingProvider.type}
+                  options={PROVIDER_TYPE_OPTIONS}
+                  style={{ width: 200 }}
+                  onChange={handleProviderTypeChange}
+                />
+              </SettingsRow>
+
+              <SettingsRow label="名称">
+                <Input
+                  value={editingProvider.name}
+                  placeholder="如：DeepSeek / 本地 Ollama"
+                  onChange={(e) =>
+                    setEditingProvider({ ...editingProvider, name: e.target.value })
+                  }
+                />
+              </SettingsRow>
+
+              <SettingsRow label="API 地址">
+                <Input
+                  value={editingProvider.baseUrl}
+                  placeholder={DEFAULT_BASE_URLS[editingProvider.type]}
+                  onChange={(e) =>
+                    setEditingProvider({ ...editingProvider, baseUrl: e.target.value })
+                  }
+                />
+              </SettingsRow>
+
+              <SettingsRow label="模型">
+                <Input
+                  value={editingProvider.model}
+                  placeholder={DEFAULT_MODELS[editingProvider.type]}
+                  onChange={(e) =>
+                    setEditingProvider({ ...editingProvider, model: e.target.value })
+                  }
+                />
+              </SettingsRow>
+
+              <SettingsRow label="API Key" hint={editingProvider.apiKeyRef ? "已存储，留空表示不更改" : ""}>
+                <Input.Password
+                  value={apiKeyInput}
+                  placeholder={editingProvider.apiKeyRef ? "留空保留原密钥" : "输入 API Key"}
+                  onChange={(e) => setApiKeyInput(e.target.value)}
+                />
+              </SettingsRow>
+
+              <SettingsSwitchRow
+                label="启用此提供商"
+                checked={editingProvider.enabled}
+                onChange={(v) =>
+                  setEditingProvider({ ...editingProvider, enabled: v })
+                }
+              />
+
+              <Space style={{ marginTop: 8 }}>
+                <Button
+                  type="primary"
+                  onClick={() => void handleSaveProvider()}
+                >
+                  保存
+                </Button>
+                <Button
+                  loading={testing}
+                  onClick={() => void handleTestProvider()}
+                >
+                  测试连接
+                </Button>
+                <Button onClick={() => setEditingProvider(null)}>取消</Button>
+              </Space>
+            </div>
+          )}
+        </SettingsCard>
+      )}
+    </>
+  );
+};

--- a/apps/desktop/src/renderer/components/settings-center/constants.ts
+++ b/apps/desktop/src/renderer/components/settings-center/constants.ts
@@ -14,6 +14,7 @@ export const SECTIONS: Array<{ key: SettingsSection; label: string; icon: string
   { key: "network", label: "网络工具", icon: "ri-route-line" },
   { key: "backup", label: "云存档", icon: "ri-cloud-line" },
   { key: "security", label: "安全与审计", icon: "ri-shield-keyhole-line" },
+  { key: "ai", label: "AI 助手", icon: "ri-robot-2-line" },
   { key: "about", label: "关于", icon: "ri-information-line" },
 ];
 

--- a/apps/desktop/src/renderer/components/settings-center/index.ts
+++ b/apps/desktop/src/renderer/components/settings-center/index.ts
@@ -8,6 +8,7 @@ export { NetworkSection } from "./network-section";
 export { RecycleBinSection } from "./recycle-bin-section";
 export { BackupSection } from "./backup-section";
 export { SecuritySection } from "./security-section";
+export { AiSection } from "./ai-section";
 export { AboutSection } from "./about-section";
 
 export type {

--- a/apps/desktop/src/renderer/components/settings-center/types.ts
+++ b/apps/desktop/src/renderer/components/settings-center/types.ts
@@ -7,6 +7,7 @@ export type SettingsSection =
   | "network"
   | "backup"
   | "security"
+  | "ai"
   | "about";
 
 export type LocalShellMode = "preset" | "custom";

--- a/apps/desktop/src/renderer/store/usePreferencesStore.ts
+++ b/apps/desktop/src/renderer/store/usePreferencesStore.ts
@@ -21,7 +21,8 @@ const clonePreferences = (prefs: AppPreferences): AppPreferences => ({
   backup: { ...prefs.backup },
   window: { ...prefs.window },
   traceroute: { ...prefs.traceroute },
-  audit: { ...prefs.audit }
+  audit: { ...prefs.audit },
+  ai: { ...prefs.ai, providers: prefs.ai.providers.map((p) => ({ ...p })) }
 });
 
 const readLegacyValue = (key: string): string | undefined => {
@@ -156,7 +157,8 @@ export const usePreferencesStore = create<PreferencesState>((set, get) => ({
       backup: { ...prev.backup, ...(patch.backup ?? {}) },
       window: { ...prev.window, ...(patch.window ?? {}) },
       traceroute: { ...prev.traceroute, ...(patch.traceroute ?? {}) },
-      audit: { ...prev.audit, ...(patch.audit ?? {}) }
+      audit: { ...prev.audit, ...(patch.audit ?? {}) },
+      ai: { ...prev.ai, ...(patch.ai ?? {}) }
     };
     set({ preferences: optimistic });
 

--- a/apps/desktop/src/renderer/utils/ai-error-message.ts
+++ b/apps/desktop/src/renderer/utils/ai-error-message.ts
@@ -1,0 +1,42 @@
+const pickRawMessage = (error: unknown): string => {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object") {
+    const data = error as Record<string, unknown>;
+    if (typeof data.error === "string") return data.error;
+    if (typeof data.message === "string") return data.message;
+    if (typeof data.reason === "string") return data.reason;
+  }
+  return "";
+};
+
+const normalize = (value: string): string => {
+  return value.replace(/^Error:\s*/i, "").replace(/\s+/g, " ").trim();
+};
+
+const AI_ERROR_PATTERNS: Array<{ label: string; summary: string; pattern: RegExp }> = [
+  { label: "配置错误", summary: "配置错误", pattern: /base url|model.*不能为空|must.*http|provider .*不能为空|\/chat\/completions|\/v1\/messages|:generatecontent/i },
+  { label: "鉴权失败", summary: "鉴权失败", pattern: /\b401\b|\b403\b|unauthorized|forbidden|invalid api key|incorrect api key|api key|authentication/i },
+  { label: "触发限流", summary: "触发限流", pattern: /\b429\b|rate limit|too many requests|quota/i },
+  { label: "请求超时", summary: "请求超时", pattern: /timed out|timeout|请求超时/i },
+  { label: "服务异常", summary: "服务异常", pattern: /\b5\d\d\b|bad gateway|service unavailable|upstream|overloaded/i },
+];
+
+const classify = (message: string): { label: string; summary: string } | undefined => {
+  return AI_ERROR_PATTERNS.find((item) => item.pattern.test(message));
+};
+
+export const formatAiErrorMessage = (error: unknown, fallback = "AI 请求失败"): string => {
+  const raw = normalize(pickRawMessage(error));
+  if (!raw) return fallback;
+
+  const matched = classify(raw);
+  if (!matched) return raw;
+  return raw.startsWith(`${matched.label}：`) ? raw : `${matched.label}：${raw}`;
+};
+
+export const summarizeAiError = (error: unknown, fallback = "AI 请求失败"): string => {
+  const raw = normalize(pickRawMessage(error));
+  if (!raw) return fallback;
+  return classify(raw)?.summary ?? fallback;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -482,6 +482,7 @@ export interface AppPreferences {
     /** 审计日志保留天数，0 表示永不清理 */
     retentionDays: number;
   };
+  ai: AiPreferences;
 }
 
 export interface AppPreferencesPatch {
@@ -547,6 +548,13 @@ export interface AppPreferencesPatch {
   audit?: {
     enabled?: boolean;
     retentionDays?: number;
+  };
+  ai?: {
+    enabled?: boolean;
+    activeProviderId?: string;
+    providers?: AiProviderConfig[];
+    systemPromptOverride?: string;
+    executionTimeoutSec?: number;
   };
 }
 
@@ -635,6 +643,135 @@ export interface ConnectionImportResult {
   errors: string[];
 }
 
+// ────── AI Assistant ──────
+
+export type AiProviderType = "openai" | "anthropic" | "gemini";
+
+export interface AiProviderConfig {
+  id: string;
+  type: AiProviderType;
+  name: string;
+  baseUrl: string;
+  model: string;
+  /** secret:// 引用，密钥不明文存储 */
+  apiKeyRef?: string;
+  enabled: boolean;
+}
+
+export interface AiPreferences {
+  enabled: boolean;
+  activeProviderId?: string;
+  providers: AiProviderConfig[];
+  systemPromptOverride?: string;
+  /** 命令执行超时（秒） */
+  executionTimeoutSec: number;
+  /** 模型请求超时（秒） */
+  providerRequestTimeoutSec: number;
+  /** 模型请求失败后的最大重试次数 */
+  providerMaxRetries: number;
+}
+
+export type AiChatRole = "user" | "assistant" | "system";
+export type AiMessageKind = "chat" | "execution_result";
+export type AiMessageType = "user_prompt" | "assistant_reply" | "execution_result" | "system_note";
+
+type AiMessageRoleLike = {
+  role: AiChatRole;
+  type?: AiMessageType;
+  kind?: AiMessageKind;
+};
+
+export const resolveAiMessageType = (message: AiMessageRoleLike): AiMessageType => {
+  if (message.type) return message.type;
+  if (message.kind === "execution_result") return "execution_result";
+  if (message.role === "assistant") return "assistant_reply";
+  if (message.role === "system") return "system_note";
+  return "user_prompt";
+};
+
+export const isAiExecutionResultMessage = (message: AiMessageRoleLike): boolean => {
+  return resolveAiMessageType(message) === "execution_result";
+};
+
+export const isAiUserPromptMessage = (message: AiMessageRoleLike): boolean => {
+  return resolveAiMessageType(message) === "user_prompt";
+};
+
+export const isAiAssistantReplyMessage = (message: AiMessageRoleLike): boolean => {
+  return resolveAiMessageType(message) === "assistant_reply";
+};
+
+export const isAiSystemNoteMessage = (message: AiMessageRoleLike): boolean => {
+  return resolveAiMessageType(message) === "system_note";
+};
+
+export const getAiMessageCanonicalRole = (message: AiMessageRoleLike): AiChatRole => {
+  const type = resolveAiMessageType(message);
+  if (type === "assistant_reply") return "assistant";
+  if (type === "user_prompt") return "user";
+  return "system";
+};
+
+export const getAiMessageModelRole = (message: AiMessageRoleLike): AiChatRole => {
+  const type = resolveAiMessageType(message);
+  if (type === "assistant_reply") return "assistant";
+  if (type === "system_note") return "system";
+  return "user";
+};
+
+export interface AiChatMessage {
+  id: string;
+  role: AiChatRole;
+  /** 业务语义字段，前端与历史恢复逻辑应优先使用它判断消息类型 */
+  type: AiMessageType;
+  /** 兼容旧历史结构，新增写入不再依赖该字段 */
+  kind?: AiMessageKind;
+  content: string;
+  timestamp: string;
+  /** 若包含执行计划，存储在此 */
+  plan?: AiExecutionPlan;
+  /** 执行进度快照 */
+  executionProgress?: AiExecutionProgress;
+}
+
+export interface AiExecutionStep {
+  step: number;
+  command: string;
+  description: string;
+  risky: boolean;
+}
+
+export interface AiExecutionPlan {
+  steps: AiExecutionStep[];
+  summary: string;
+}
+
+export type AiStepStatus = "pending" | "running" | "success" | "failed" | "skipped";
+
+export interface AiStepResult {
+  step: number;
+  status: AiStepStatus;
+  output?: string;
+  error?: string;
+}
+
+export interface AiExecutionProgress {
+  planSummary: string;
+  steps: AiStepResult[];
+  currentStep: number;
+  completed: boolean;
+}
+
+export interface AiConversation {
+  id: string;
+  title: string;
+  messages: AiChatMessage[];
+  sessionId?: string;
+  connectionId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export const DEFAULT_APP_PREFERENCES: AppPreferences = {
   transfer: {
     uploadDefaultDir: "~",
@@ -698,6 +835,15 @@ export const DEFAULT_APP_PREFERENCES: AppPreferences = {
   audit: {
     enabled: false,
     retentionDays: 7
+  },
+  ai: {
+    enabled: false,
+    activeProviderId: undefined,
+    providers: [],
+    systemPromptOverride: undefined,
+    executionTimeoutSec: 30,
+    providerRequestTimeoutSec: 30,
+    providerMaxRetries: 1
   }
 };
 

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AiConversation,
   AuditLogRecord,
   BackupArchiveMeta,
   BatchCommandExecutionResult,
@@ -118,6 +119,14 @@ import type {
   UpdateCheckResult,
   PingRequestInput,
   PingResult,
+  AiChatInput,
+  AiApproveInput,
+  AiAbortInput,
+  AiHistoryInput,
+  AiProviderTestInput,
+  AiProviderSetApiKeyInput,
+  AiStreamEvent,
+  AiProgressEvent,
   CloudSyncWorkspaceAddInput,
   CloudSyncWorkspaceUpdateInput,
   CloudSyncWorkspaceRemoveInput,
@@ -336,5 +345,15 @@ export interface NextShellApi {
     restore: (payload: RecycleBinRestoreInput) => Promise<ConnectionProfile | SshKeyProfile>;
     purge: (payload: RecycleBinPurgeInput) => Promise<{ ok: true }>;
     clear: () => Promise<{ ok: true; deleted: number }>;
+  };
+  ai: {
+    chat: (payload: AiChatInput) => Promise<{ conversationId: string }>;
+    approve: (payload: AiApproveInput) => Promise<{ ok: true }>;
+    abort: (payload: AiAbortInput) => Promise<{ ok: true }>;
+    history: (payload?: AiHistoryInput) => Promise<AiConversation[]>;
+    testProvider: (payload: AiProviderTestInput) => Promise<{ ok: boolean; error?: string }>;
+    setApiKey: (payload: AiProviderSetApiKeyInput) => Promise<{ ok: true }>;
+    onStream: (listener: (event: AiStreamEvent) => void) => SessionEventUnsubscribe;
+    onProgress: (listener: (event: AiProgressEvent) => void) => SessionEventUnsubscribe;
   };
 }

--- a/packages/shared/src/channels.ts
+++ b/packages/shared/src/channels.ts
@@ -122,5 +122,15 @@ export const IPCChannel = {
   RecycleBinClear: "nextshell:recycle-bin:clear",
 
   // ── Resource Operations (SSH Key) ──
-  ResourceCopySshKey: "nextshell:resource:copy-ssh-key"
+  ResourceCopySshKey: "nextshell:resource:copy-ssh-key",
+
+  // ── AI Assistant ──
+  AiChat: "nextshell:ai:chat",
+  AiApprove: "nextshell:ai:approve",
+  AiAbort: "nextshell:ai:abort",
+  AiHistory: "nextshell:ai:history",
+  AiProviderTest: "nextshell:ai:provider:test",
+  AiProviderSetApiKey: "nextshell:ai:provider:set-api-key",
+  AiStreamEvent: "nextshell:ai:stream:event",
+  AiProgressEvent: "nextshell:ai:progress:event"
 } as const;

--- a/packages/shared/src/contracts.preferences.test.ts
+++ b/packages/shared/src/contracts.preferences.test.ts
@@ -15,6 +15,8 @@ const assert = (condition: boolean, message: string): void => {
 
   const parsed = appPreferencesSchema.parse({});
   assert(parsed.audit.enabled === false, "audit should default to disabled in schema parsing");
+  assert(parsed.ai.providerRequestTimeoutSec === 30, "ai provider timeout should default to 30 seconds");
+  assert(parsed.ai.providerMaxRetries === 1, "ai provider retries should default to 1");
 })();
 
 (() => {
@@ -52,6 +54,17 @@ const assert = (condition: boolean, message: string): void => {
   });
 
   assert(parsed.success, "appPreferencesPatchSchema should accept workspace layout booleans");
+})();
+
+(() => {
+  const parsed = appPreferencesPatchSchema.safeParse({
+    ai: {
+      providerRequestTimeoutSec: 45,
+      providerMaxRetries: 2
+    }
+  });
+
+  assert(parsed.success, "appPreferencesPatchSchema should accept ai provider runtime settings");
 })();
 
 (() => {

--- a/packages/shared/src/contracts.ts
+++ b/packages/shared/src/contracts.ts
@@ -404,6 +404,8 @@ const localShellSchema = z.object({
   }
 });
 
+export const aiProviderTypeSchema = z.enum(["openai", "anthropic", "gemini"]);
+
 export const appPreferencesSchema = z.object({
   transfer: z.object({
     uploadDefaultDir: z.string().min(1).default(DEFAULT_APP_PREFERENCES.transfer.uploadDefaultDir),
@@ -463,7 +465,24 @@ export const appPreferencesSchema = z.object({
   audit: z.object({
     enabled: z.boolean().default(DEFAULT_APP_PREFERENCES.audit.enabled),
     retentionDays: z.coerce.number().int().min(0).max(365).default(DEFAULT_APP_PREFERENCES.audit.retentionDays)
-  }).default(DEFAULT_APP_PREFERENCES.audit)
+  }).default(DEFAULT_APP_PREFERENCES.audit),
+  ai: z.object({
+    enabled: z.boolean().default(DEFAULT_APP_PREFERENCES.ai.enabled),
+    activeProviderId: z.string().optional(),
+    providers: z.array(z.object({
+      id: z.string(),
+      type: aiProviderTypeSchema,
+      name: z.string(),
+      baseUrl: z.string(),
+      model: z.string(),
+      apiKeyRef: z.string().optional(),
+      enabled: z.boolean()
+    })).default(DEFAULT_APP_PREFERENCES.ai.providers),
+    systemPromptOverride: z.string().optional(),
+    executionTimeoutSec: z.coerce.number().int().min(5).max(300).default(DEFAULT_APP_PREFERENCES.ai.executionTimeoutSec),
+    providerRequestTimeoutSec: z.coerce.number().int().min(5).max(120).default(DEFAULT_APP_PREFERENCES.ai.providerRequestTimeoutSec),
+    providerMaxRetries: z.coerce.number().int().min(0).max(3).default(DEFAULT_APP_PREFERENCES.ai.providerMaxRetries)
+  }).default(DEFAULT_APP_PREFERENCES.ai)
 }).default(DEFAULT_APP_PREFERENCES);
 
 export const appPreferencesPatchSchema = z.object({
@@ -537,6 +556,23 @@ export const appPreferencesPatchSchema = z.object({
   audit: z.object({
     enabled: z.boolean().optional(),
     retentionDays: z.coerce.number().int().min(0).max(365).optional()
+  }).optional(),
+  ai: z.object({
+    enabled: z.boolean().optional(),
+    activeProviderId: z.string().optional(),
+    providers: z.array(z.object({
+      id: z.string(),
+      type: aiProviderTypeSchema,
+      name: z.string(),
+      baseUrl: z.string(),
+      model: z.string(),
+      apiKeyRef: z.string().optional(),
+      enabled: z.boolean()
+    })).optional(),
+    systemPromptOverride: z.string().optional(),
+    executionTimeoutSec: z.coerce.number().int().min(5).max(300).optional(),
+    providerRequestTimeoutSec: z.coerce.number().int().min(5).max(120).optional(),
+    providerMaxRetries: z.coerce.number().int().min(0).max(3).optional()
   }).optional()
 });
 
@@ -1020,3 +1056,75 @@ export type RecycleBinRestoreInput = z.infer<typeof recycleBinRestoreSchema>;
 export type RecycleBinPurgeInput = z.infer<typeof recycleBinPurgeSchema>;
 export type RecycleBinClearInput = z.infer<typeof recycleBinClearSchema>;
 export type ResourceCopySshKeyInput = z.infer<typeof resourceCopySshKeySchema>;
+
+// ─── AI Assistant ────────────────────────────────────────────────────────
+
+export const aiChatSchema = z.object({
+  conversationId: z.string().uuid().optional(),
+  message: z.string().trim().min(1),
+  sessionId: z.string().uuid().optional(),
+  connectionId: z.string().uuid().optional(),
+});
+
+export const aiApproveSchema = z.object({
+  conversationId: z.string().uuid(),
+  plan: z.object({
+    steps: z.array(z.object({
+      step: z.number(),
+      command: z.string(),
+      description: z.string(),
+      risky: z.boolean(),
+    })),
+    summary: z.string(),
+  }).optional(),
+});
+
+export const aiAbortSchema = z.object({
+  conversationId: z.string().uuid(),
+});
+
+export const aiHistorySchema = z.object({
+  connectionId: z.string().uuid().optional(),
+});
+
+export const aiProviderTestSchema = z.object({
+  type: aiProviderTypeSchema,
+  baseUrl: z.string().trim().min(1),
+  model: z.string().trim().min(1),
+  apiKey: z.string().min(1),
+});
+
+export const aiProviderSetApiKeySchema = z.object({
+  providerId: z.string().trim().min(1),
+  apiKey: z.string().min(1),
+});
+
+export type AiChatInput = z.infer<typeof aiChatSchema>;
+export type AiApproveInput = z.infer<typeof aiApproveSchema>;
+export type AiAbortInput = z.infer<typeof aiAbortSchema>;
+export type AiHistoryInput = z.infer<typeof aiHistorySchema>;
+export type AiProviderTestInput = z.infer<typeof aiProviderTestSchema>;
+export type AiProviderSetApiKeyInput = z.infer<typeof aiProviderSetApiKeySchema>;
+
+export interface AiStreamEvent {
+  conversationId: string;
+  type: "token" | "plan" | "done" | "error";
+  token?: string;
+  fullContent?: string;
+  plan?: {
+    steps: Array<{ step: number; command: string; description: string; risky: boolean }>;
+    summary: string;
+  };
+  error?: string;
+}
+
+export interface AiProgressEvent {
+  conversationId: string;
+  type: "step_start" | "step_output" | "step_done" | "all_done" | "analysis_start" | "error";
+  step?: number;
+  command?: string;
+  output?: string;
+  status?: "running" | "success" | "failed";
+  error?: string;
+  summary?: string;
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -465,7 +465,11 @@ const cloneDefaultPreferences = (): AppPreferences => {
     backup: { ...DEFAULT_APP_PREFERENCES_VALUE.backup },
     window: { ...DEFAULT_APP_PREFERENCES_VALUE.window },
     traceroute: { ...DEFAULT_APP_PREFERENCES_VALUE.traceroute },
-    audit: { ...DEFAULT_APP_PREFERENCES_VALUE.audit }
+    audit: { ...DEFAULT_APP_PREFERENCES_VALUE.audit },
+    ai: {
+      ...DEFAULT_APP_PREFERENCES_VALUE.ai,
+      providers: DEFAULT_APP_PREFERENCES_VALUE.ai.providers.map((p) => ({ ...p }))
+    }
   };
 };
 
@@ -736,6 +740,44 @@ const parseAppPreferences = (value: string | null): AppPreferences => {
           parsed.audit.retentionDays <= 365
             ? parsed.audit.retentionDays
             : fallback.audit.retentionDays
+      },
+      ai: {
+        enabled:
+          typeof parsed.ai?.enabled === "boolean"
+            ? parsed.ai.enabled
+            : fallback.ai.enabled,
+        activeProviderId:
+          typeof parsed.ai?.activeProviderId === "string"
+            ? parsed.ai.activeProviderId
+            : fallback.ai.activeProviderId,
+        providers: Array.isArray(parsed.ai?.providers)
+          ? parsed.ai.providers
+          : fallback.ai.providers,
+        systemPromptOverride:
+          typeof parsed.ai?.systemPromptOverride === "string"
+            ? parsed.ai.systemPromptOverride
+            : fallback.ai.systemPromptOverride,
+        executionTimeoutSec:
+          typeof parsed.ai?.executionTimeoutSec === "number" &&
+          Number.isInteger(parsed.ai.executionTimeoutSec) &&
+          parsed.ai.executionTimeoutSec >= 5 &&
+          parsed.ai.executionTimeoutSec <= 300
+            ? parsed.ai.executionTimeoutSec
+            : fallback.ai.executionTimeoutSec,
+        providerRequestTimeoutSec:
+          typeof parsed.ai?.providerRequestTimeoutSec === "number" &&
+          Number.isInteger(parsed.ai.providerRequestTimeoutSec) &&
+          parsed.ai.providerRequestTimeoutSec >= 5 &&
+          parsed.ai.providerRequestTimeoutSec <= 120
+            ? parsed.ai.providerRequestTimeoutSec
+            : fallback.ai.providerRequestTimeoutSec,
+        providerMaxRetries:
+          typeof parsed.ai?.providerMaxRetries === "number" &&
+          Number.isInteger(parsed.ai.providerMaxRetries) &&
+          parsed.ai.providerMaxRetries >= 0 &&
+          parsed.ai.providerMaxRetries <= 3
+            ? parsed.ai.providerMaxRetries
+            : fallback.ai.providerMaxRetries
       }
     };
   } catch {


### PR DESCRIPTION
## 背景

  - 这是对已关闭 PR #22 的重拆版本
  - 本 PR 在 #25 的基础上，补齐主进程侧 AI 服务运行时与命令执行安全边界
  - 建议审阅顺序：#25 -> #26 -> #27

  ## 本 PR 包含

  - 新增多提供商 LLM adapters
    - OpenAI-compatible
    - Anthropic
    - Gemini
  - 新增 `LlmRouter`
  - 新增 `AiService`
  - 新增执行计划解析、输出截断与分析提示模板
  - 新增 `AiExecutionCoordinator`，收敛 AI 执行流程与状态
  - 接入 IPC 注册与主进程容器依赖注入
  - 增加 AI 执行边界保护
  - 支持在当前 session shell 中执行已批准命令
  - 隐藏 AI 控制信令，避免中间 shell 窗口暴露包装命令与退出码污染

  ## 主要文件

  - `apps/desktop/src/main/services/ai/adapters/*`
  - `apps/desktop/src/main/services/ai/ai-service.ts`
  - `apps/desktop/src/main/services/ai/ai-execution-coordinator.ts`
  - `apps/desktop/src/main/services/ai/llm-router.ts`
  - `apps/desktop/src/main/services/ai/output-capture.ts`
  - `apps/desktop/src/main/services/ai/plan-guard.ts`
  - `apps/desktop/src/main/services/ai/plan-parser.ts`
  - `apps/desktop/src/main/services/ai/prompt-templates.ts`
  - `apps/desktop/src/main/ipc/register.ts`
  - `apps/desktop/src/main/services/container.ts`
  - `apps/desktop/src/main/services/command-service.ts`
  - `apps/desktop/src/main/services/session-service.ts`

  ## 评审建议

  本 PR 是累积分支，包含 #25 的基础改动。

  建议 reviewer 重点看相对 #25 新增的内容：

  1. `AiService` 与 `AiExecutionCoordinator` 的职责边界
  2. LLM provider adapter 设计是否一致
  3. AI 执行时的安全边界与中止/超时处理
  4. session shell 真执行与输出过滤逻辑是否可靠

  ## 补充说明

  本 PR 已包含当前分支上对 session shell 体验的两项关键修复：

  - 让 AI 批准后的命令在当前 session shell 真实执行
  - 将 AI 控制信令与用户可见终端输出分离

  ## 后续关系

  - #27 会在本 PR 基础上补齐 renderer 侧 AI Chat 面板与交互体验