### PR TITLE
fix: 修复终端底部行被裁切

### DIFF
--- a/apps/desktop/src/renderer/components/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/components/TerminalPane.tsx
@@ -1018,9 +1018,9 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(({
   const hasSession = !!sessionIdRef.current;
 
   return (
-    <div className="flex-1 min-h-0 flex flex-col">
+    <div className="flex-1 min-h-0 flex flex-col pb-1">
       <div
-        className="flex-1 min-h-0 py-1.5 px-1"
+        className="flex-1 min-h-0 box-border overflow-hidden py-1.5 px-1"
         ref={containerRef}
         onContextMenu={handleContextMenu}
       />


### PR DESCRIPTION
## 变更内容

修复中间 shell 终端视图过于贴底，导致最后一行内容显示不全的问题。

### 这次改动
- 调整终端外层容器布局，增加轻量底部安全区
- 调整终端挂载容器的 box model，避免内容高度计算贴底后裁切最后一行

### 影响文件
- `apps/desktop/src/renderer/components/TerminalPane.tsx`

### 验证
- `bunx tsc --noEmit -p apps/desktop/tsconfig.web.json`
- 本地手动确认终端最后一行已完整显示

### 背景
- 该 PR 从 `origin/main` 独立切分，只包含终端底部行裁切修复，不依赖其他 AI/布局改动。